### PR TITLE
Checking whether the "default NetVM" exists

### DIFF
--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -260,11 +260,13 @@ class VMSettingsWindow(Ui_SettingsDialog, QDialog):
             netvm_list = [vm for vm in self.qvm_collection.values() if not vm.internal and vm.is_netvm() and vm.qid != 0]
             self.netvm_idx = -1
 
-            text = "default ("+self.qvm_collection.get_default_netvm().name+")"
-            if self.vm.uses_default_netvm:
-                text += " (current)"
-                self.netvm_idx = 0
-            self.netVM.insertItem(0, text)
+            default_netvm = self.qvm_collection.get_default_netvm()
+            if default_netvm is not None:
+                text = "default (%s)" % default_netvm.name
+                if self.vm.uses_default_netvm:
+                    text += " (current)"
+                    self.netvm_idx = 0
+                self.netVM.insertItem(0, text)
 
             for (i, vm) in enumerate(netvm_list):
                 text = vm.name


### PR DESCRIPTION
The "default NetVM" is usually the first created ProxyVM which is
set by qubes-core during its creation. [1] If there is no ProxyVM,
there is no "default NetVM". Therefore, creating an AppVM and
launching its settings dialog raised AttributeError, because
get_default_netvm method returned None.

This can be reproduced by installing QubesOS without creating VMs
by installer.

[1] https://github.com/QubesOS/qubes-core-admin/blob/master/core/qubes.py#L355

Fixes qubesos/qubes-issues#1008