### PR TITLE
trimed exception popup message text quite a bit. Fixes QubesOS/qubes-…

### DIFF
--- a/qubesmanager/main.py
+++ b/qubesmanager/main.py
@@ -1985,8 +1985,10 @@ def handle_exception(exc_type, exc_value, exc_traceback):
 
     filename, line, dummy, dummy = traceback.extract_tb(exc_traceback).pop()
     filename = os.path.basename(filename)
+    error = "%s: %s" % (exc_type.__name__, exc_value)
+    error = error.replace('QubesException: ', '')
     message = (
-        "<b>%s</b>" % exc_value +
+        "<b>%s</b>" % error +
         "<br><br><i>This is most likely a bug in the Qubes Manager</i>"
     )
     is_gui_thread = threading.currentThread().getName() == "QtMainThread"

--- a/qubesmanager/main.py
+++ b/qubesmanager/main.py
@@ -1985,13 +1985,9 @@ def handle_exception(exc_type, exc_value, exc_traceback):
 
     filename, line, dummy, dummy = traceback.extract_tb(exc_traceback).pop()
     filename = os.path.basename(filename)
-    error = "%s: %s" % (exc_type.__name__, exc_value)
     message = (
-        "Whoops. A critical error has occured. This is most likely a bug "
-        "in Qubes Manager.<br><br>"
-        "<b><i>%s</i></b>" % error +
-        "<br/>at line <b>%d</b><br/>of file %s.<br/><br/>"
-        % (line, filename)
+        "<b>%s</b>" % exc_value +
+        "<br><br><i>This is most likely a bug in the Qubes Manager</i>"
     )
     is_gui_thread = threading.currentThread().getName() == "QtMainThread"
     strace = ""


### PR DESCRIPTION
…issues#1394

@marmarek how important / varried is the output of `exc_type.__name__` is it things other than `QubesException` which might be helpful to the user? I opted to trim that part out showing just the value of `exc_value` but could instead do something like

```
error = "%s: %s" % (exc_type.__name__, exc_value)
error = error.replace('QubesException: ', '')
```