### PR TITLE
Clarify language in services tab

### DIFF
--- a/settingsdlg.ui
+++ b/settingsdlg.ui
@@ -1120,7 +1120,7 @@
          <item row="8" column="0" colspan="2">
           <widget class="QLabel" name="label_9">
            <property name="text">
-            <string>Unlisted services will follow default VM's settings.</string>
+            <string>Unlisted services will follow default settings.</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
The services tab says that unlisted services will, "follow default VM's settings."  When I happened to see this, I was confused: which default VM?  The default NetVM?  The default TemplateVM?

After some investigating in this repo and in 000QubesVm.py, I've come to understand that they simply take on *default* values, not the values from some *default VM*.

If this is not correct, and this request should be rejected, the language should definitely still be clarified!