### PR TITLE
Require typing name of VM to remove

### DIFF
--- a/qubesmanager/main.py
+++ b/qubesmanager/main.py
@@ -1011,15 +1011,25 @@ class VmManagerWindow(Ui_VmManagerWindow, QMainWindow):
 
                 return
 
-        reply = QMessageBox.question(
+        (requested_name, ok) = QInputDialog.getText(
             None, "VM Removal Confirmation",
             "Are you sure you want to remove the VM <b>'{0}'</b>?<br>"
-            "<small>All data on this VM's private storage will be lost!</small>"
-            .format(vm.name),
-            QMessageBox.Yes | QMessageBox.Cancel)
+            "All data on this VM's private storage will be lost!<br><br>"
+            "Type the name of the VM (<b>{1}</b>) below to confirm:"
+            .format(vm.name, vm.name))
 
-        if reply == QMessageBox.Yes:
+        if not ok:
+            # user clicked cancel
+            return
 
+        elif requested_name != vm.name:
+            # name did not match
+            QMessageBox.warning(None, "VM removal confirmation failed",
+                "Entered name did not match! Not removing {0}.".format(vm.name))
+            return
+
+        else:
+            # remove the VM
             thread_monitor = ThreadMonitor()
             thread = threading.Thread(target=self.do_remove_vm,
                                       args=(vm, thread_monitor))


### PR DESCRIPTION
IMO it is too easy to accidentally delete the wrong VM if you use lots of short-term (but longer than disposable) VMs and have built muscle memory of just clicking "Ok" in the deletion confirmation box.

This patch requires you to type the full name of the VM, inspired by repo deletion confirmation on GitHub.

The confirmation box looks like this:
![confirm-delete](https://cloud.githubusercontent.com/assets/1231207/20512346/bdb479ca-b04c-11e6-9803-fc3f80238b63.png)

And if you type it wrong, you get this:
![confirm-wrong](https://cloud.githubusercontent.com/assets/1231207/20512353/c7e44074-b04c-11e6-9870-b33cfbf68887.png)
