### PR TITLE
Implement searching for VMs in qubes-manager

### DIFF
--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -59,6 +59,12 @@
     </property>
     <item row="0" column="0">
      <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="spacing">
+       <number>6</number>
+      </property>
+      <property name="leftMargin">
+       <number>6</number>
+      </property>
       <item>
        <widget class="QLabel" name="label">
         <property name="text">

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -58,6 +58,9 @@
      <number>0</number>
     </property>
     <item row="0" column="0">
+     <widget class="QLineEdit" name="searchbox"/>
+    </item>
+    <item row="1" column="0">
      <widget class="QTableWidget" name="table">
       <property name="minimumSize">
        <size>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -58,7 +58,18 @@
      <number>0</number>
     </property>
     <item row="0" column="0">
-     <widget class="QLineEdit" name="searchbox"/>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Search:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="searchbox"/>
+      </item>
+     </layout>
     </item>
     <item row="1" column="0">
      <widget class="QTableWidget" name="table">


### PR DESCRIPTION
Example:
![search-fedora](https://cloud.githubusercontent.com/assets/1231207/20554164/1decb470-b128-11e6-9b68-de8fdeb92602.png)

Some UX person (@bnvk?) might want to improve the placement or something, idk, but it's a HUGE usability improvement as-is for me, and likely anyone else who has 50+ VMs.