### PR TITLE
Add keyboard shortcuts for manager menu items

### DIFF
--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -259,7 +259,7 @@
    </property>
    <widget class="QMenu" name="menu_system">
     <property name="title">
-     <string>System</string>
+     <string>&amp;System</string>
     </property>
     <addaction name="action_global_settings"/>
     <addaction name="action_backup"/>
@@ -267,7 +267,7 @@
    </widget>
    <widget class="QMenu" name="menu_view">
     <property name="title">
-     <string>View</string>
+     <string>&amp;View</string>
     </property>
     <addaction name="action_vm_type"/>
     <addaction name="action_label"/>
@@ -293,11 +293,11 @@
    </widget>
    <widget class="QMenu" name="menu_vm">
     <property name="title">
-     <string>VM</string>
+     <string>V&amp;M</string>
     </property>
     <widget class="QMenu" name="logs_menu">
      <property name="title">
-      <string>Logs</string>
+      <string>&amp;Logs</string>
      </property>
      <property name="icon">
       <iconset resource="resources.qrc">
@@ -306,7 +306,7 @@
     </widget>
     <widget class="QMenu" name="blk_menu">
      <property name="title">
-      <string>Attach/detach block devices</string>
+      <string>Attach/detach &amp;block devices</string>
      </property>
      <property name="icon">
       <iconset resource="resources.qrc">
@@ -336,7 +336,7 @@
    </widget>
    <widget class="QMenu" name="menu_about">
     <property name="title">
-     <string>About</string>
+     <string>&amp;About</string>
     </property>
     <addaction name="action_about_qubes"/>
    </widget>
@@ -391,7 +391,7 @@
      <normaloff>:/createvm.png</normaloff>:/createvm.png</iconset>
    </property>
    <property name="text">
-    <string>Create VM</string>
+    <string>Create &amp;New VM</string>
    </property>
    <property name="toolTip">
     <string>Create a new VM</string>
@@ -406,7 +406,7 @@
      <normaloff>:/removevm.png</normaloff>:/removevm.png</iconset>
    </property>
    <property name="text">
-    <string>Remove VM</string>
+    <string>&amp;Delete VM</string>
    </property>
    <property name="toolTip">
     <string>Remove an existing VM (must be stopped first)</string>
@@ -421,7 +421,7 @@
      <normaloff>:/resumevm.png</normaloff>:/resumevm.png</iconset>
    </property>
    <property name="text">
-    <string>Start/Resume VM</string>
+    <string>Start/Resume V&amp;M</string>
    </property>
    <property name="toolTip">
     <string>Start/Resume selected VM</string>
@@ -436,7 +436,7 @@
      <normaloff>:/pausevm.png</normaloff>:/pausevm.png</iconset>
    </property>
    <property name="text">
-    <string>Pause VM</string>
+    <string>&amp;Pause VM</string>
    </property>
    <property name="toolTip">
     <string>Pause selected VM</string>
@@ -451,7 +451,7 @@
      <normaloff>:/shutdownvm.png</normaloff>:/shutdownvm.png</iconset>
    </property>
    <property name="text">
-    <string>Shutdown VM</string>
+    <string>&amp;Shutdown VM</string>
    </property>
    <property name="toolTip">
     <string>Shutdown selected VM</string>
@@ -466,7 +466,7 @@
      <normaloff>:/restartvm.png</normaloff>:/restartvm.png</iconset>
    </property>
    <property name="text">
-    <string>Restart VM</string>
+    <string>Restar&amp;t VM</string>
    </property>
    <property name="toolTip">
     <string>Restart selected VM</string>
@@ -481,7 +481,7 @@
      <normaloff>:/apps.png</normaloff>:/apps.png</iconset>
    </property>
    <property name="text">
-    <string>Add/remove app shortcuts</string>
+    <string>Add/remove app s&amp;hortcuts</string>
    </property>
    <property name="toolTip">
     <string>Add/remove app shortcuts for this VM</string>
@@ -496,7 +496,7 @@
      <normaloff>:/updateable.png</normaloff>:/updateable.png</iconset>
    </property>
    <property name="text">
-    <string>Update VM</string>
+    <string>&amp;Update VM</string>
    </property>
    <property name="toolTip">
     <string>Update VM system</string>
@@ -511,7 +511,7 @@
      <normaloff>:/mic.png</normaloff>:/mic.png</iconset>
    </property>
    <property name="text">
-    <string>Attach/detach audio-input to the VM</string>
+    <string>Attach/detach &amp;audio-input to the VM</string>
    </property>
    <property name="toolTip">
     <string>Attach/detach audio-input to the VM</string>
@@ -542,7 +542,7 @@
      <normaloff>:/firewall.png</normaloff>:/firewall.png</iconset>
    </property>
    <property name="text">
-    <string>Edit VM firewall rules</string>
+    <string>Edit VM &amp;firewall rules</string>
    </property>
    <property name="toolTip">
     <string>Edit VM firewall rules</string>
@@ -581,7 +581,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>CPU</string>
+    <string>&amp;CPU</string>
    </property>
   </action>
   <action name="action_cpu_graph">
@@ -592,7 +592,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>CPU Graph</string>
+    <string>CPU &amp;Graph</string>
    </property>
   </action>
   <action name="action_mem">
@@ -603,7 +603,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>MEM</string>
+    <string>&amp;MEM</string>
    </property>
   </action>
   <action name="action_mem_graph">
@@ -614,7 +614,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>MEM Graph</string>
+    <string>M&amp;EM Graph</string>
    </property>
   </action>
   <action name="action_template">
@@ -625,7 +625,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Template</string>
+    <string>&amp;Template</string>
    </property>
   </action>
   <action name="action_netvm">
@@ -636,7 +636,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>NetVM</string>
+    <string>&amp;NetVM</string>
    </property>
   </action>
   <action name="action_settings">
@@ -645,7 +645,7 @@
      <normaloff>:/settings.png</normaloff>:/settings.png</iconset>
    </property>
    <property name="text">
-    <string>VM settings</string>
+    <string>VM s&amp;ettings</string>
    </property>
    <property name="toolTip">
     <string>VM Settings</string>
@@ -657,7 +657,7 @@
      <normaloff>:/restore.png</normaloff>:/restore.png</iconset>
    </property>
    <property name="text">
-    <string>Restore VMs from backup</string>
+    <string>&amp;Restore VMs from backup</string>
    </property>
   </action>
   <action name="action_backup">
@@ -666,7 +666,7 @@
      <normaloff>:/backup.png</normaloff>:/backup.png</iconset>
    </property>
    <property name="text">
-    <string>Backup VMs</string>
+    <string>&amp;Backup VMs</string>
    </property>
   </action>
   <action name="action_global_settings">
@@ -675,7 +675,7 @@
      <normaloff>:/global-settings.png</normaloff>:/global-settings.png</iconset>
    </property>
    <property name="text">
-    <string>Global settings</string>
+    <string>&amp;Global settings</string>
    </property>
   </action>
   <action name="action_state">
@@ -686,7 +686,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>State</string>
+    <string>&amp;State</string>
    </property>
   </action>
   <action name="action_killvm">
@@ -695,7 +695,7 @@
      <normaloff>:/killvm.png</normaloff>:/killvm.png</iconset>
    </property>
    <property name="text">
-    <string>Kill VM</string>
+    <string>&amp;Kill VM</string>
    </property>
    <property name="toolTip">
     <string>Kill selected VM</string>
@@ -707,7 +707,7 @@
      <normaloff>:/kbd-layout.png</normaloff>:/kbd-layout.png</iconset>
    </property>
    <property name="text">
-    <string>Set keyboard layout</string>
+    <string>Set keyboard la&amp;yout</string>
    </property>
    <property name="toolTip">
     <string>Set keyboard layout per VM</string>
@@ -721,7 +721,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Type</string>
+    <string>T&amp;ype</string>
    </property>
    <property name="toolTip">
     <string>VM Type</string>
@@ -735,7 +735,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Label</string>
+    <string>&amp;Label</string>
    </property>
   </action>
   <action name="action_name">
@@ -746,7 +746,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Name</string>
+    <string>N&amp;ame</string>
    </property>
   </action>
   <action name="action_toolbar">
@@ -776,7 +776,7 @@
     <iconset theme="qubes-manager"/>
    </property>
    <property name="text">
-    <string>Qubes OS</string>
+    <string>&amp;Qubes OS</string>
    </property>
   </action>
   <action name="action_size_on_disk">
@@ -787,7 +787,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Size</string>
+    <string>Si&amp;ze</string>
    </property>
    <property name="toolTip">
     <string>Size on Disk</string>
@@ -799,7 +799,7 @@
      <normaloff>:/run-command.png</normaloff>:/run-command.png</iconset>
    </property>
    <property name="text">
-    <string>Run command in VM</string>
+    <string>&amp;Run command in VM</string>
    </property>
    <property name="toolTip">
     <string>Run command in the specified VM</string>
@@ -814,7 +814,7 @@
      <normaloff>:/templatevm.png</normaloff>:/templatevm.png</iconset>
    </property>
    <property name="text">
-    <string>Clone VM</string>
+    <string>&amp;Clone VM</string>
    </property>
   </action>
   <action name="action_internal">
@@ -825,7 +825,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Internal</string>
+    <string>Inte&amp;rnal</string>
    </property>
    <property name="toolTip">
     <string>Is an internal VM</string>
@@ -869,7 +869,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>IP</string>
+    <string>&amp;IP</string>
    </property>
   </action>
   <action name="action_backups">
@@ -880,7 +880,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Include in backups</string>
+    <string>Include in &amp;backups</string>
    </property>
   </action>
   <action name="action_last_backup">
@@ -891,7 +891,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Last backup</string>
+    <string>Last back&amp;up</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Triggered in standard Qt way with Alt+X to open the menu, and the underlined letter to perform that action.

Example (`Alt+M - N` to create new VM, `Alt+M - K` to Kill selected, etc.):
![shortcuts](https://cloud.githubusercontent.com/assets/1231207/20588523/d2fbb9cc-b1e3-11e6-968d-38ea7e8e62ed.png)