### PR TITLE
Make inter-appviewer lock permissions consistent

### DIFF
--- a/qubesmanager/log_dialog.py
+++ b/qubesmanager/log_dialog.py
@@ -74,7 +74,7 @@ def copy_text_to_qubes_clipboard(text):
     #inter-appviewer lock
 
     try:
-        fd = os.open("/var/run/qubes/appviewer.lock", os.O_RDWR|os.O_CREAT, 0600)
+        fd = os.open("/var/run/qubes/appviewer.lock", os.O_RDWR|os.O_CREAT, 0666)
         fcntl.flock(fd, fcntl.LOCK_EX)
     except IOError:
         QMessageBox.warning (None, "Warning!", "Error while accessing Qubes clipboard!")


### PR DESCRIPTION
[Currently in gui-daemon/xside.c (only other holder of the lock):](https://github.com/QubesOS/qubes-gui-daemon/blob/95417c573d9b24269d50b3733164c3c9e390851c/gui-daemon/xside.c#L428-L435)

```
    g->inter_appviewer_lock_fd = open("/var/run/qubes/appviewer.lock",
        O_RDWR | O_CREAT, 0666);
    ...
    /* ignore possible errors */
    fchmod(g->inter_appviewer_lock_fd, 0666);
```
