### PR TITLE
Implement "Copy Dom0 clipboard" tray menu item

### DIFF
--- a/qubesmanager/clipboard.py
+++ b/qubesmanager/clipboard.py
@@ -2,6 +2,7 @@
 #
 # The Qubes OS Project, http://www.qubes-os.org
 #
+# Copyright (C) 2016  Jean-Philippe Ouellet <jpo@vt.edu>
 # Copyright (C) 2012  Agnieszka Kostrzewa <agnieszka.kostrzewa@gmail.com>
 # Copyright (C) 2012  Marek Marczykowski <marmarek@mimuw.edu.pl>
 #
@@ -39,19 +40,20 @@ def copy_text_to_qubes_clipboard(text):
 
     try:
         fd = os.open(APPVIEWER_LOCK, os.O_RDWR|os.O_CREAT, 0666)
-        fcntl.flock(fd, fcntl.LOCK_EX)
     except:
         QMessageBox.warning(None, "Warning!", "Error while accessing Qubes clipboard!")
-        return
-
-    try:
-        with open(CLIPBOARD_CONTENTS, "w") as contents:
-            contents.write(text)
-        with open(CLIPBOARD_SOURCE, "w") as source:
-            source.write("dom0")
-    except:
-        QMessageBox.warning(None, "Warning!", "Error while writing to Qubes clipboard!")
-    finally:
-        fcntl.flock(fd, fcntl.LOCK_UN)
+    else:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        except:
+            QMessageBox.warning(None, "Warning!", "Error while locking Qubes clipboard!")
+        else:
+            try:
+                with open(CLIPBOARD_CONTENTS, "w") as contents:
+                    contents.write(text)
+                with open(CLIPBOARD_SOURCE, "w") as source:
+                    source.write("dom0")
+            except:
+                QMessageBox.warning(None, "Warning!", "Error while writing to Qubes clipboard!")
+            fcntl.flock(fd, fcntl.LOCK_UN)
         os.close(fd)
-        return

--- a/qubesmanager/clipboard.py
+++ b/qubesmanager/clipboard.py
@@ -1,0 +1,56 @@
+#!/usr/bin/python2
+#
+# The Qubes OS Project, http://www.qubes-os.org
+#
+# Copyright (C) 2012  Agnieszka Kostrzewa <agnieszka.kostrzewa@gmail.com>
+# Copyright (C) 2012  Marek Marczykowski <marmarek@mimuw.edu.pl>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+#
+
+import os
+import fcntl
+
+from qubes.qubes import QubesException
+from PyQt4.QtGui import QApplication
+
+def do_dom0_copy():
+    copy_text_to_qubes_clipboard(QApplication.clipboard().text())
+
+def copy_text_to_qubes_clipboard(text):
+    #inter-appviewer lock
+
+    try:
+        fd = os.open("/var/run/qubes/appviewer.lock", os.O_RDWR|os.O_CREAT, 0666)
+        fcntl.flock(fd, fcntl.LOCK_EX)
+    except IOError:
+        QMessageBox.warning (None, "Warning!", "Error while accessing Qubes clipboard!")
+        return
+
+    qubes_clipboard = open("/var/run/qubes/qubes-clipboard.bin", 'w')
+    qubes_clipboard.write(text)
+    qubes_clipboard.close()
+
+    qubes_clip_source = open("/var/run/qubes/qubes-clipboard.bin.source", 'w')
+    qubes_clip_source.write("dom0")
+    qubes_clip_source.close()
+
+    try:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+    except IOError:
+        QMessageBox.warning (None, "Warning!", "Error while writing to Qubes clipboard!")
+        return

--- a/qubesmanager/log_dialog.py
+++ b/qubesmanager/log_dialog.py
@@ -23,7 +23,6 @@
 
 import sys
 import os
-import fcntl
 from PyQt4.QtCore import *
 from PyQt4.QtGui import *
 
@@ -32,6 +31,7 @@ from qubes.qubes import QubesException
 import qubesmanager.resources_rc
 
 from ui_logdlg import *
+from clipboard import *
 
 # Display only this size of log
 LOG_DISPLAY_SIZE = 1024*1024
@@ -67,31 +67,3 @@ class LogDialog(Ui_LogDialog, QDialog):
 
     def copy_to_qubes_clipboard_triggered(self):
         copy_text_to_qubes_clipboard(self.displayed_text)
-        
-########################COPY TEXT TO QUBES CLIPBOARD
-
-def copy_text_to_qubes_clipboard(text):
-    #inter-appviewer lock
-
-    try:
-        fd = os.open("/var/run/qubes/appviewer.lock", os.O_RDWR|os.O_CREAT, 0666)
-        fcntl.flock(fd, fcntl.LOCK_EX)
-    except IOError:
-        QMessageBox.warning (None, "Warning!", "Error while accessing Qubes clipboard!")
-        return
-
-    qubes_clipboard = open("/var/run/qubes/qubes-clipboard.bin", 'w')
-    qubes_clipboard.write(text)
-    qubes_clipboard.close()
-        
-    qubes_clip_source = open("/var/run/qubes/qubes-clipboard.bin.source", 'w')
-    qubes_clip_source.write("dom0")
-    qubes_clip_source.close()
-
-    try:
-        fcntl.flock(fd, fcntl.LOCK_UN)
-        os.close(fd)
-    except IOError:
-        QMessageBox.warning (None, "Warning!", "Error while writing to Qubes clipboard!")
-        return
-    

--- a/qubesmanager/main.py
+++ b/qubesmanager/main.py
@@ -57,6 +57,7 @@ from backup import BackupVMsWindow
 from global_settings import GlobalSettingsWindow
 from log_dialog import LogDialog
 from thread_monitor import *
+from clipboard import *
 
 
 qubes_clipboard_info_file = "/var/run/qubes/qubes-clipboard.bin.source"
@@ -1751,6 +1752,8 @@ class QubesTrayIcon(QSystemTrayIcon):
 
         action_showmanager = self.create_action("Open VM Manager",
                                                 slot=show_manager, icon="qubes")
+        action_copy = self.create_action("Copy Dom0 clipboard", icon="copy",
+                                         slot=do_dom0_copy)
         action_backup = self.create_action("Make backup")
         action_preferences = self.create_action("Preferences")
         action_set_netvm = self.create_action("Set default NetVM",
@@ -1771,6 +1774,7 @@ class QubesTrayIcon(QSystemTrayIcon):
         action_blk_menu.setMenu(self.blk_menu)
 
         self.add_actions(self.menu, (action_showmanager,
+                                     action_copy,
                                      action_blk_menu,
                                      action_backup,
                                      action_sys_info,

--- a/rpm_spec/qmgr.spec
+++ b/rpm_spec/qmgr.spec
@@ -38,6 +38,7 @@ cp qubesmanager/mount_for_backup.sh $RPM_BUILD_ROOT/usr/libexec/qubes-manager/
 
 mkdir -p $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager/
 cp qubesmanager/main.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
+cp qubesmanager/clipboard.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
 cp qubesmanager/block.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
 cp qubesmanager/table_widgets.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
 cp qubesmanager/appmenu_select.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
@@ -97,6 +98,9 @@ rm -rf $RPM_BUILD_ROOT
 %{python_sitearch}/qubesmanager/main.py
 %{python_sitearch}/qubesmanager/main.pyc
 %{python_sitearch}/qubesmanager/main.pyo
+%{python_sitearch}/qubesmanager/clipboard.py
+%{python_sitearch}/qubesmanager/clipboard.pyc
+%{python_sitearch}/qubesmanager/clipboard.pyo
 %{python_sitearch}/qubesmanager/block.py
 %{python_sitearch}/qubesmanager/block.pyc
 %{python_sitearch}/qubesmanager/block.pyo


### PR DESCRIPTION
Ctrl+Shift+C would be preferable, but is quite difficult to do safely,
and this method seems like a reasonable security/UX compromise.

Discussed in:
- https://groups.google.com/forum/#!topic/qubes-devel/4_x7Su21i9o
- https://github.com/QubesOS/qubes-issues/issues/2438#issuecomment-261704575

Fixes https://github.com/QubesOS/qubes-issues/issues/2450