### PR TITLE
Fix for UnicodeEncodeError in search

### DIFF
--- a/qubesmanager/main.py
+++ b/qubesmanager/main.py
@@ -719,7 +719,7 @@ class VmManagerWindow(Ui_VmManagerWindow, QMainWindow):
 
     @pyqtSlot(str)
     def do_search(self, search):
-        self.search = str(search)
+        self.search = unicode(search)
         self.showhide_vms()
         self.set_table_geom_size()
 


### PR DESCRIPTION
Entering non-ascii characters (e.g. "ą") in search
causes an UnicodeEncodeError. This is a quick fix.

Fixes QubesOS/qubes-issues#2562