### PR TITLE
backups: Explain why passwords are always required

### DIFF
--- a/backupdlg.ui
+++ b/backupdlg.ui
@@ -242,6 +242,16 @@
          </property>
         </widget>
        </item>
+       <item row="6" column="1">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>&lt;b&gt;Note:&lt;/b&gt; Even if you choose not to encrypt your backup, a password is still required in order to provide authenticated verification of the data. See the emergency restore instructions for more info.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
     </item>


### PR DESCRIPTION
I had someone tell me IRL that they thought the fact that it still asked for a password when "Encrypt backup" was unchecked was a bug. This is not the case, so explain why.

I think this wording is more user-friendly than "also used for an HMAC" or such.

Fixes https://github.com/QubesOS/qubes-issues/issues/2365