### PR TITLE
Show size of current inter-VM clipboard in Ctrl-Shift-C notification

### DIFF
--- a/qubesmanager/clipboard.py
+++ b/qubesmanager/clipboard.py
@@ -24,6 +24,7 @@
 
 import os
 import fcntl
+from math import log
 
 from qubes.qubes import QubesException
 from PyQt4.QtGui import QApplication
@@ -57,3 +58,20 @@ def copy_text_to_qubes_clipboard(text):
                 QMessageBox.warning(None, "Warning!", "Error while writing to Qubes clipboard!")
             fcntl.flock(fd, fcntl.LOCK_UN)
         os.close(fd)
+
+def get_qubes_clipboard_formatted_size():
+    units = ['B', 'KiB', 'MiB', 'GiB']
+
+    try:
+        file_size = os.path.getsize(CLIPBOARD_CONTENTS)
+    except:
+        QMessageBox.warning(None, "Warning!", "Error while accessing Qubes clipboard!")
+    else:
+        formatted_bytes = '1 byte' if file_size == 1 else str(file_size) + ' bytes'
+        if file_size > 0:
+            magnitude = min(int(log(file_size)/log(2)*0.1), len(units)-1)
+            if magnitude > 0:
+                return '%s (%.1f %s)' % (formatted_bytes, file_size/(2.0**(10*magnitude)), units[magnitude])
+        return '%s' % (formatted_bytes)
+
+    return '? bytes'

--- a/qubesmanager/main.py
+++ b/qubesmanager/main.py
@@ -109,6 +109,7 @@ class QubesManagerFileWatcher(ProcessEvent):
                     " VM's clipboard.</small>")).format(
                         src_vmname, get_qubes_clipboard_formatted_size()),
                         msecs=3000)
+            src_info_file.close()
 
     def process_IN_CREATE(self, event):
         if event.name == os.path.basename(qubes_clipboard_info_file):

--- a/qubesmanager/main.py
+++ b/qubesmanager/main.py
@@ -104,10 +104,11 @@ class QubesManagerFileWatcher(ProcessEvent):
             else:
                 trayIcon.showMessage(unicode(app.tr(
                     "Qubes Clipboard fetched from VM: <b>'{0}'</b>\n"
+                    "Copied <b>{1}</b> to the clipboard.\n"
                     "<small>Press Ctrl-Shift-v to copy this clipboard into dest"
                     " VM's clipboard.</small>")).format(
-                        src_vmname), msecs=3000)
-            src_info_file.close()
+                        src_vmname, get_qubes_clipboard_formatted_size()),
+                        msecs=3000)
 
     def process_IN_CREATE(self, event):
         if event.name == os.path.basename(qubes_clipboard_info_file):


### PR DESCRIPTION
QubesOS/qubes-issues#2825

Shows size in bytes if less than one KiB: 
> Copied **40 bytes** to the clipboard.

Shows size in bytes and units (up to GiB), rounded to one decimal place, if more than one KiB: 
> Copied **1904 bytes (1.9 KiB)** to the clipboard.

Are there any translation considerations for 'bytes'?