### PR TITLE
New api for globalsettings & python3 for qubesmanager

### DIFF
--- a/globalsettingsdlg.ui
+++ b/globalsettingsdlg.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>678</width>
-    <height>318</height>
+    <height>331</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -158,13 +158,6 @@
         </property>
         <property name="singleStep">
          <number>50</number>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="dispvm_in_memory">
-        <property name="text">
-         <string>Keep dispVM in memory</string>
         </property>
        </widget>
       </item>

--- a/qubesmanager/backup.py
+++ b/qubesmanager/backup.py
@@ -327,7 +327,7 @@ class BackupVMsWindow(Ui_Backup, QWizard):
             if ex.tmpdir:
                 self.tmpdir_to_remove = ex.tmpdir
         except Exception as ex:
-            print "Exception:", ex
+            print("Exception:", ex)
             msg.append(str(ex))
 
         if len(msg) > 0 :
@@ -352,7 +352,7 @@ class BackupVMsWindow(Ui_Backup, QWizard):
                         print_callback = self.gather_output,
                         hide_vm_names=self.encryption_checkbox.isChecked())
             except Exception as ex:
-                print "Exception:", ex
+                print("Exception:", ex)
                 QMessageBox.critical(None,
                     self.tr("Error while preparing backup."),
                     unicode(self.tr("ERROR: {0}")).format(ex))

--- a/qubesmanager/clipboard.py
+++ b/qubesmanager/clipboard.py
@@ -40,7 +40,7 @@ def copy_text_to_qubes_clipboard(text):
     #inter-appviewer lock
 
     try:
-        fd = os.open(APPVIEWER_LOCK, os.O_RDWR|os.O_CREAT, 0666)
+        fd = os.open(APPVIEWER_LOCK, os.O_RDWR|os.O_CREAT, 0o0666)
     except:
         QMessageBox.warning(None, "Warning!", "Error while accessing Qubes clipboard!")
     else:

--- a/qubesmanager/global_settings.py
+++ b/qubesmanager/global_settings.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 #
 # The Qubes OS Project, http://www.qubes-os.org
 #
@@ -26,29 +26,14 @@ import os
 from PyQt4.QtCore import *
 from PyQt4.QtGui import *
 
-from qubes.qubes import QubesVmCollection
-from qubes.qubes import QubesException
-from qubes.qubes import QubesDaemonPidfile
-from qubes.qubes import QubesHost
-from qubes.qubes import system_path
+from qubesadmin import Qubes
 
-import qubesmanager.resources_rc
+from qubesmanager.ui_globalsettingsdlg import *
 
-from pyinotify import WatchManager, Notifier, ThreadedNotifier, EventsCodes, ProcessEvent
+from configparser import ConfigParser
+from qubesadmin.utils import parse_size, updates_vms_status
+from qubesadmin.vm import TemplateVM
 
-import time
-import threading
-from operator import itemgetter
-
-from ui_globalsettingsdlg import *
-
-from ConfigParser import SafeConfigParser
-from qubes.qubesutils import parse_size
-from qubes.qubesutils import updates_dom0_toggle,updates_vms_toggle,\
-    updates_dom0_status,updates_vms_status
-from qubes import qmemman_algo
-
-dont_keep_dvm_in_memory_path = '/var/lib/qubes/dvmdata/dont-use-shm'
 qmemman_config_path = '/etc/qubes/qmemman.conf'
 
 
@@ -70,14 +55,14 @@ class GlobalSettingsWindow(Ui_GlobalSettings, QDialog):
         self.__init_mem_defaults__()
         self.__init_updates__()
 
-
     def __init_system_defaults__(self):
-        #updatevm and clockvm
-        all_vms = [vm for vm in self.qvm_collection.values() if not
-        vm.internal and vm.qid != 0]
+        # updatevm and clockvm
+        all_vms = [vm for vm in self.qvm_collection.domains
+                   if (not vm.features.get('internal', False)) and vm.qid != 0]
+
         self.updatevm_idx = -1
 
-        current_update_vm = self.qvm_collection.get_updatevm_vm()
+        current_update_vm = self.qvm_collection.updatevm
         for (i, vm) in enumerate(all_vms):
             text = vm.name
             if vm is current_update_vm:
@@ -89,10 +74,10 @@ class GlobalSettingsWindow(Ui_GlobalSettings, QDialog):
             self.updatevm_idx = len(all_vms)
         self.update_vm_combo.setCurrentIndex(self.updatevm_idx)
 
-        #clockvm 
+        # clockvm
         self.clockvm_idx = -1
 
-        current_clock_vm = self.qvm_collection.get_clockvm_vm()
+        current_clock_vm = self.qvm_collection.clockvm
         for (i, vm) in enumerate(all_vms):
             text = vm.name
             if vm is current_clock_vm:
@@ -104,11 +89,11 @@ class GlobalSettingsWindow(Ui_GlobalSettings, QDialog):
             self.clockvm_idx = len(all_vms)
         self.clock_vm_combo.setCurrentIndex(self.clockvm_idx)
 
-        #default netvm
-        netvms = [vm for vm in all_vms if vm.is_netvm()]
+        # default netvm
+        netvms = [vm for vm in all_vms if getattr(vm, 'provides_network', False)]
         self.netvm_idx = -1
 
-        current_netvm = self.qvm_collection.get_default_netvm()
+        current_netvm = self.qvm_collection.default_netvm
         for (i, vm) in enumerate(netvms):
             text = vm.name
             if vm is current_netvm:
@@ -119,10 +104,10 @@ class GlobalSettingsWindow(Ui_GlobalSettings, QDialog):
             self.default_netvm_combo.setCurrentIndex(self.netvm_idx)
 
         #default template
-        templates = [vm for vm in all_vms if vm.is_template()]
+        templates = [vm for vm in all_vms if isinstance(vm, TemplateVM)]
         self.template_idx = -1
 
-        current_template = self.qvm_collection.get_default_template()
+        current_template = self.qvm_collection.default_template
         for (i, vm) in enumerate(templates):
             text = vm.name
             if vm is current_template:
@@ -137,49 +122,46 @@ class GlobalSettingsWindow(Ui_GlobalSettings, QDialog):
         if self.update_vm_combo.currentIndex() != self.updatevm_idx:
             updatevm_name = str(self.update_vm_combo.currentText())
             updatevm_name = updatevm_name.split(' ')[0]
-            updatevm = self.qvm_collection.get_vm_by_name(updatevm_name)
+            updatevm = self.qvm_collection.domains[updatevm_name]
             
-            self.qvm_collection.set_updatevm_vm(updatevm)
-            self.anything_changed = True
+            self.qvm_collection.updatevm = updatevm
 
         #clockvm
         if self.clock_vm_combo.currentIndex() != self.clockvm_idx:
             clockvm_name = str(self.clock_vm_combo.currentText())
             clockvm_name = clockvm_name.split(' ')[0]
-            clockvm = self.qvm_collection.get_vm_by_name(clockvm_name)
+            clockvm = self.qvm_collection.domains[clockvm_name]
             
-            self.qvm_collection.set_clockvm_vm(clockvm)
-            self.anything_changed = True
+            self.qvm_collection.clockvm = clockvm
 
         #default netvm
         if self.default_netvm_combo.currentIndex() != self.netvm_idx:
             name = str(self.default_netvm_combo.currentText())
             name = name.split(' ')[0]
-            vm = self.qvm_collection.get_vm_by_name(name)
+            vm = self.qvm_collection.domains[name]
             
-            self.qvm_collection.set_default_netvm(vm)
-            self.anything_changed = True
+            self.qvm_collection.default_netvm = vm
 
         #default template
         if self.default_template_combo.currentIndex() != self.template_idx:
             name = str(self.default_template_combo.currentText())
             name = name.split(' ')[0]
-            vm = self.qvm_collection.get_vm_by_name(name)
+            vm = self.qvm_collection.domains[name]
             
-            self.qvm_collection.set_default_template(vm)
-            self.anything_changed = True
+            self.qvm_collection.default_template = vm
 
 
     def __init_kernel_defaults__(self):
         kernel_list = []
-        for k in os.listdir(system_path["qubes_kernels_base_dir"]):
+        # TODO system_path["qubes_kernels_base_dir"] idea: qubes.pulls['linux-kernel'].volumes
+        for k in os.listdir('/var/lib/qubes/vm-kernels'):
             kernel_list.append(k)
 
         self.kernel_idx = 0
 
         for (i, k) in enumerate(kernel_list):
             text = k
-            if k == self.qvm_collection.get_default_kernel():
+            if k == self.qvm_collection.default_kernel:
                 text += self.tr(" (current)")
                 self.kernel_idx = i
             self.default_kernel_combo.insertItem(i, text)
@@ -190,16 +172,15 @@ class GlobalSettingsWindow(Ui_GlobalSettings, QDialog):
             kernel = str(self.default_kernel_combo.currentText())
             kernel = kernel.split(' ')[0]
             
-            self.qvm_collection.set_default_kernel(kernel)
-            self.anything_changed = True
+            self.qvm_collection.default_kernel = kernel
 
         
     def __init_mem_defaults__(self):
 
         #qmemman settings
-        self.qmemman_config = SafeConfigParser()
-        self.vm_min_mem_val =  str(qmemman_algo.MIN_PREFMEM)
-        self.dom0_mem_boost_val = str(qmemman_algo.DOM0_MEM_BOOST)
+        self.qmemman_config = ConfigParser()
+        self.vm_min_mem_val =  '200MiB'  #str(qmemman_algo.MIN_PREFMEM)
+        self.dom0_mem_boost_val = '350MiB' #str(qmemman_algo.DOM0_MEM_BOOST)
         
         self.qmemman_config.read(qmemman_config_path)
         if self.qmemman_config.has_section('global'):
@@ -212,11 +193,7 @@ class GlobalSettingsWindow(Ui_GlobalSettings, QDialog):
         self.min_vm_mem.setValue(self.vm_min_mem_val/1024/1024)
         self.dom0_mem_boost.setValue(self.dom0_mem_boost_val/1024/1024)
 
-        #keep dispvm in memory
-        exists = os.path.exists(dont_keep_dvm_in_memory_path)
-        self.dispvm_in_memory.setChecked( not exists)
 
-    
     def __apply_mem_defaults__(self):
 
         #qmemman settings
@@ -233,7 +210,7 @@ class GlobalSettingsWindow(Ui_GlobalSettings, QDialog):
                 self.qmemman_config.add_section('global')
                 self.qmemman_config.set('global', 'vm-min-mem', current_min_vm_mem)
                 self.qmemman_config.set('global', 'dom0-mem-boost', current_dom0_mem_boost)
-                self.qmemman_config.set('global', 'cache-margin-factor', str(qmemman_algo.CACHE_FACTOR))
+                self.qmemman_config.set('global', 'cache-margin-factor', str(1.3)) # removed qmemman_algo.CACHE_FACTOR
 
                 qmemman_config_file = open(qmemman_config_path, 'a')
                 self.qmemman_config.write(qmemman_config_file)
@@ -268,22 +245,11 @@ class GlobalSettingsWindow(Ui_GlobalSettings, QDialog):
                 qmemman_config_file.writelines(config_lines)
                 qmemman_config_file.close()
 
-            self.anything_changed = True
-        
-        #keep dispvm in memory
-        was_checked = not os.path.exists(dont_keep_dvm_in_memory_path)
-        if was_checked != self.dispvm_in_memory.isChecked():
-            if was_checked:
-                #touch file
-                open(dont_keep_dvm_in_memory_path, 'w').close()
-            else:
-                #rm file
-                os.remove(dont_keep_dvm_in_memory_path)
-            self.anything_changed = True
 
     def __init_updates__(self):
         self.updates_val = False
-        self.updates_dom0_val = updates_dom0_status(self.qvm_collection)
+        # TODO updates_dom0_status(self.qvm_collection)
+        self.updates_dom0_val = True
         self.updates_dom0.setChecked(self.updates_dom0_val)
         updates_vms = updates_vms_status(self.qvm_collection)
         if updates_vms is None:
@@ -293,33 +259,28 @@ class GlobalSettingsWindow(Ui_GlobalSettings, QDialog):
 
     def __apply_updates__(self):
         if self.updates_dom0.isChecked() != self.updates_dom0_val:
-            updates_dom0_toggle(self.qvm_collection, self.updates_dom0.isChecked())
+            # TODO updates_dom0_toggle(self.qvm_collection, self.updates_dom0.isChecked())
+            raise NotImplementedError('Toggle dom0 updates not implemented')
         if self.updates_vm.checkState() != Qt.PartiallyChecked:
-            self.anything_changed = True
-            updates_vms_toggle(self.qvm_collection, self.updates_vm
-                               .isChecked())
+            for vm in self.qvm_collection.domains:
+                vm.features['check-updates'] = bool(self.updates_vm.checkState())
 
     def reject(self):
         self.done(0)
 
     def save_and_apply(self):
-        self.qvm_collection.lock_db_for_writing()
-    
-        self.anything_changed = False
+
         self.__apply_system_defaults__()        
         self.__apply_kernel_defaults__()
         self.__apply_mem_defaults__()
         self.__apply_updates__()
 
-        if self.anything_changed == True:
-            self.qvm_collection.save()
-        self.qvm_collection.unlock_db()
+
 
 # Bases on the original code by:
 # Copyright (c) 2002-2007 Pascal Varet <p.varet@gmail.com>
 
 def handle_exception( exc_type, exc_value, exc_traceback ):
-    import sys
     import os.path
     import traceback
 
@@ -337,31 +298,23 @@ def handle_exception( exc_type, exc_value, exc_traceback ):
 
 def main():
 
-    global qubes_host
-    qubes_host = QubesHost()
-
-    global app
-    app = QApplication(sys.argv)
-    app.setOrganizationName("The Qubes Project")
-    app.setOrganizationDomain("http://qubes-os.org")
-    app.setApplicationName("Qubes Global Settings")
+    global qtapp
+    qtapp = QApplication(sys.argv)
+    qtapp.setOrganizationName("The Qubes Project")
+    qtapp.setOrganizationDomain("http://qubes-os.org")
+    qtapp.setApplicationName("Qubes Global Settings")
 
     sys.excepthook = handle_exception
 
-    qvm_collection = QubesVmCollection()
-    qvm_collection.lock_db_for_reading()
-    qvm_collection.load()
-    qvm_collection.unlock_db()
+    app = Qubes()
 
     global global_window
-    global_window = GlobalSettingsWindow()
+    global_window = GlobalSettingsWindow(qtapp, app)
 
     global_window.show()
 
-    app.exec_()
-    app.exit()
-
-
+    qtapp.exec_()
+    qtapp.exit()
 
 if __name__ == "__main__":
     main()

--- a/qubesmanager/main.py
+++ b/qubesmanager/main.py
@@ -899,7 +899,7 @@ class VmManagerWindow(Ui_VmManagerWindow, QMainWindow):
                                    QString("org.QubesOS.Audio"),  # interface
                                    QString("RecAllowedChanged"),  # name
                                    self.recAllowedChanged):  # slot
-            print session_bus.lastError().message()
+            print(session_bus.lastError().message())
 
     # noinspection PyPep8Naming
     def sortIndicatorChanged(self, column, order):
@@ -1207,7 +1207,7 @@ class VmManagerWindow(Ui_VmManagerWindow, QMainWindow):
             return
 
 
-	self.start_vm(vm)
+    self.start_vm(vm)
 
     def start_vm(self, vm):
         assert not vm.is_running()
@@ -2121,7 +2121,7 @@ def handle_exception(exc_type, exc_value, exc_traceback):
 
         msg_box.exec_()
     else:
-        print >>sys.stderr, message
+        print(message, file=sys.stderr)
 
 def sighup_handler(signum, frame):
     os.execl("/usr/bin/qubes-manager", "qubes-manager")

--- a/qubesmanager/qvm_net.py
+++ b/qubesmanager/qvm_net.py
@@ -26,14 +26,14 @@ def tree(netvm, padding):
         else:
             vm_name  = qvm_collection[vm].name
         if qvm_collection[vm].is_template():
-            print padding,'|->',vm_name,'(Tpl)'
+            print(padding,'|->',vm_name,'(Tpl)')
         else:
-            print padding,'|->',vm_name
+            print(padding,'|->',vm_name)
         if qvm_collection[vm].is_netvm() :
             tree(qvm_collection[vm], padding)         
           
 padding=''
 for vm in qvm_collection:
     if qvm_collection[vm].is_netvm() and not qvm_collection[vm].netvm :
-        print qvm_collection[vm].name
+        print(qvm_collection[vm].name)
         tree(qvm_collection[vm], padding)

--- a/qubesmanager/restore.py
+++ b/qubesmanager/restore.py
@@ -190,7 +190,7 @@ class RestoreVMsWindow(Ui_Restore, QWizard):
             self.tmpdir_to_remove = ex.tmpdir
             err_msg.append(unicode(ex))
         except Exception as ex:
-            print "Exception:", ex
+            print ("Exception:", ex)
             err_msg.append(unicode(ex))
             err_msg.append(
                 self.tr("Partially restored files left in "

--- a/rpm_spec/qmgr.spec
+++ b/rpm_spec/qmgr.spec
@@ -1,5 +1,3 @@
-%global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib(1)")
-
 %{!?version: %define version %(cat version)}
 
 Name:		qubes-manager
@@ -11,11 +9,13 @@ Group:		Qubes
 Vendor:		Invisible Things Lab
 License:	GPL
 URL:		http://fixme
-Requires:	python, PyQt4, qubes-core-dom0-linux >= 2.0.22, qubes-core-dom0 >= 3.0.18
+Requires:	python3, PyQt4, qubes-core-dom0-linux >= 2.0.22, qubes-core-dom0 >= 3.0.18
 Requires:	pmount, cryptsetup, wmctrl
 Requires:	dbus
 Requires:	qubes-artwork
-BuildRequires:	PyQt4-devel
+BuildRequires:	python3-PyQt4-devel
+BuildRequires:  python3-devel
+BuildRequires:  qt-devel
 AutoReq:	0
 
 %define _builddir %(pwd)
@@ -25,8 +25,8 @@ The Graphical Qubes VM Manager.
 
 %build
 make res translations
-python -m compileall qubesmanager
-python -O -m compileall qubesmanager
+python3 -m compileall qubesmanager
+python3 -O -m compileall qubesmanager
 
 %install
 mkdir -p $RPM_BUILD_ROOT/usr/bin/
@@ -37,47 +37,13 @@ mkdir -p $RPM_BUILD_ROOT/usr/libexec/qubes-manager/
 cp qubesmanager/mount_for_backup.sh $RPM_BUILD_ROOT/usr/libexec/qubes-manager/
 cp qubesmanager/qvm_about.sh $RPM_BUILD_ROOT/usr/libexec/qubes-manager/
 cp qubesmanager/qvm_net.py $RPM_BUILD_ROOT/usr/libexec/qubes-manager/
-cp qubesmanager/qvm_net.pyo $RPM_BUILD_ROOT/usr/libexec/qubes-manager/
-cp qubesmanager/qvm_net.pyc $RPM_BUILD_ROOT/usr/libexec/qubes-manager/
 
-mkdir -p $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager/
-cp qubesmanager/main.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/clipboard.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/block.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/table_widgets.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/appmenu_select.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/backup.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/backup_utils.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/firewall.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/global_settings.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/multiselectwidget.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/restore.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/settings.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/log_dialog.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/about.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/releasenotes.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/informationnotes.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/networknotes.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/create_new_vm.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/thread_monitor.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/resources_rc.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/__init__.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/ui_backupdlg.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/ui_globalsettingsdlg.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/ui_mainwindow.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/ui_multiselectwidget.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/ui_newappvmdlg.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/ui_newfwruledlg.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/ui_restoredlg.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/ui_settingsdlg.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/ui_logdlg.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/ui_about.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/ui_releasenotes.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/ui_informationnotes.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
-cp qubesmanager/ui_networknotes.py{,c,o} $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager
+mkdir -p $RPM_BUILD_ROOT%{python3_sitelib}/qubesmanager/
+cp -r qubesmanager/__pycache__ $RPM_BUILD_ROOT%{python3_sitelib}/qubesmanager/
+cp qubesmanager/*.py $RPM_BUILD_ROOT%{python3_sitelib}/qubesmanager/
 
-mkdir -p $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager/i18n
-cp i18n/qubesmanager_*.qm $RPM_BUILD_ROOT%{python_sitearch}/qubesmanager/i18n/
+mkdir -p $RPM_BUILD_ROOT%{python3_sitelib}/qubesmanager/i18n
+cp i18n/qubesmanager_*.qm $RPM_BUILD_ROOT%{python3_sitelib}/qubesmanager/i18n/
 
 mkdir -p $RPM_BUILD_ROOT/usr/share/applications
 cp qubes-manager.desktop $RPM_BUILD_ROOT/usr/share/applications
@@ -106,110 +72,44 @@ rm -rf $RPM_BUILD_ROOT
 /usr/libexec/qubes-manager/qvm_net.py
 /usr/libexec/qubes-manager/qvm_net.pyo
 /usr/libexec/qubes-manager/qvm_net.pyc
-%dir %{python_sitearch}/qubesmanager
-%{python_sitearch}/qubesmanager/__init__.py
-%{python_sitearch}/qubesmanager/__init__.pyo
-%{python_sitearch}/qubesmanager/__init__.pyc
-%{python_sitearch}/qubesmanager/main.py
-%{python_sitearch}/qubesmanager/main.pyc
-%{python_sitearch}/qubesmanager/main.pyo
-%{python_sitearch}/qubesmanager/clipboard.py
-%{python_sitearch}/qubesmanager/clipboard.pyc
-%{python_sitearch}/qubesmanager/clipboard.pyo
-%{python_sitearch}/qubesmanager/block.py
-%{python_sitearch}/qubesmanager/block.pyc
-%{python_sitearch}/qubesmanager/block.pyo
-%{python_sitearch}/qubesmanager/table_widgets.py
-%{python_sitearch}/qubesmanager/table_widgets.pyc
-%{python_sitearch}/qubesmanager/table_widgets.pyo
-%{python_sitearch}/qubesmanager/appmenu_select.py
-%{python_sitearch}/qubesmanager/appmenu_select.pyc
-%{python_sitearch}/qubesmanager/appmenu_select.pyo
-%{python_sitearch}/qubesmanager/backup.py
-%{python_sitearch}/qubesmanager/backup.pyc
-%{python_sitearch}/qubesmanager/backup.pyo
-%{python_sitearch}/qubesmanager/backup_utils.py
-%{python_sitearch}/qubesmanager/backup_utils.pyc
-%{python_sitearch}/qubesmanager/backup_utils.pyo
-%{python_sitearch}/qubesmanager/firewall.py
-%{python_sitearch}/qubesmanager/firewall.pyc
-%{python_sitearch}/qubesmanager/firewall.pyo
-%{python_sitearch}/qubesmanager/global_settings.py
-%{python_sitearch}/qubesmanager/global_settings.pyc
-%{python_sitearch}/qubesmanager/global_settings.pyo
-%{python_sitearch}/qubesmanager/multiselectwidget.py
-%{python_sitearch}/qubesmanager/multiselectwidget.pyc
-%{python_sitearch}/qubesmanager/multiselectwidget.pyo
-%{python_sitearch}/qubesmanager/restore.py
-%{python_sitearch}/qubesmanager/restore.pyc
-%{python_sitearch}/qubesmanager/restore.pyo
-%{python_sitearch}/qubesmanager/settings.py
-%{python_sitearch}/qubesmanager/settings.pyc
-%{python_sitearch}/qubesmanager/settings.pyo
-%{python_sitearch}/qubesmanager/log_dialog.py
-%{python_sitearch}/qubesmanager/log_dialog.pyc
-%{python_sitearch}/qubesmanager/log_dialog.pyo
-%{python_sitearch}/qubesmanager/about.py
-%{python_sitearch}/qubesmanager/about.pyc
-%{python_sitearch}/qubesmanager/about.pyo
-%{python_sitearch}/qubesmanager/releasenotes.py
-%{python_sitearch}/qubesmanager/releasenotes.pyc
-%{python_sitearch}/qubesmanager/releasenotes.pyo
-%{python_sitearch}/qubesmanager/informationnotes.py
-%{python_sitearch}/qubesmanager/informationnotes.pyc
-%{python_sitearch}/qubesmanager/informationnotes.pyo
-%{python_sitearch}/qubesmanager/networknotes.py
-%{python_sitearch}/qubesmanager/networknotes.pyc
-%{python_sitearch}/qubesmanager/networknotes.pyo
-%{python_sitearch}/qubesmanager/create_new_vm.py
-%{python_sitearch}/qubesmanager/create_new_vm.pyc
-%{python_sitearch}/qubesmanager/create_new_vm.pyo
-%{python_sitearch}/qubesmanager/thread_monitor.py
-%{python_sitearch}/qubesmanager/thread_monitor.pyc
-%{python_sitearch}/qubesmanager/thread_monitor.pyo
-%{python_sitearch}/qubesmanager/resources_rc.py
-%{python_sitearch}/qubesmanager/resources_rc.pyc
-%{python_sitearch}/qubesmanager/resources_rc.pyo
-%{python_sitearch}/qubesmanager/ui_backupdlg.py
-%{python_sitearch}/qubesmanager/ui_backupdlg.pyc
-%{python_sitearch}/qubesmanager/ui_backupdlg.pyo
-%{python_sitearch}/qubesmanager/ui_globalsettingsdlg.py
-%{python_sitearch}/qubesmanager/ui_globalsettingsdlg.pyc
-%{python_sitearch}/qubesmanager/ui_globalsettingsdlg.pyo
-%{python_sitearch}/qubesmanager/ui_mainwindow.py
-%{python_sitearch}/qubesmanager/ui_mainwindow.pyc
-%{python_sitearch}/qubesmanager/ui_mainwindow.pyo
-%{python_sitearch}/qubesmanager/ui_multiselectwidget.py
-%{python_sitearch}/qubesmanager/ui_multiselectwidget.pyc
-%{python_sitearch}/qubesmanager/ui_multiselectwidget.pyo
-%{python_sitearch}/qubesmanager/ui_newappvmdlg.py
-%{python_sitearch}/qubesmanager/ui_newappvmdlg.pyc
-%{python_sitearch}/qubesmanager/ui_newappvmdlg.pyo
-%{python_sitearch}/qubesmanager/ui_newfwruledlg.py
-%{python_sitearch}/qubesmanager/ui_newfwruledlg.pyc
-%{python_sitearch}/qubesmanager/ui_newfwruledlg.pyo
-%{python_sitearch}/qubesmanager/ui_restoredlg.py
-%{python_sitearch}/qubesmanager/ui_restoredlg.pyc
-%{python_sitearch}/qubesmanager/ui_restoredlg.pyo
-%{python_sitearch}/qubesmanager/ui_settingsdlg.py
-%{python_sitearch}/qubesmanager/ui_settingsdlg.pyc
-%{python_sitearch}/qubesmanager/ui_settingsdlg.pyo
-%{python_sitearch}/qubesmanager/ui_logdlg.py
-%{python_sitearch}/qubesmanager/ui_logdlg.pyc
-%{python_sitearch}/qubesmanager/ui_logdlg.pyo
-%{python_sitearch}/qubesmanager/ui_about.py
-%{python_sitearch}/qubesmanager/ui_about.pyc
-%{python_sitearch}/qubesmanager/ui_about.pyo
-%{python_sitearch}/qubesmanager/ui_releasenotes.py
-%{python_sitearch}/qubesmanager/ui_releasenotes.pyc
-%{python_sitearch}/qubesmanager/ui_releasenotes.pyo
-%{python_sitearch}/qubesmanager/ui_informationnotes.py
-%{python_sitearch}/qubesmanager/ui_informationnotes.pyc
-%{python_sitearch}/qubesmanager/ui_informationnotes.pyo
-%{python_sitearch}/qubesmanager/ui_networknotes.py
-%{python_sitearch}/qubesmanager/ui_networknotes.pyc
-%{python_sitearch}/qubesmanager/ui_networknotes.pyo
-%{python_sitearch}/qubesmanager/i18n/qubesmanager_*.qm
+%dir %{python3_sitelib}/qubesmanager
+%{python3_sitelib}/qubesmanager/__pycache__
+%{python3_sitelib}/qubesmanager/__init__.py
+%{python3_sitelib}/qubesmanager/main.py
+%{python3_sitelib}/qubesmanager/clipboard.py
+%{python3_sitelib}/qubesmanager/block.py
+%{python3_sitelib}/qubesmanager/table_widgets.py
+%{python3_sitelib}/qubesmanager/appmenu_select.py
+%{python3_sitelib}/qubesmanager/backup.py
+%{python3_sitelib}/qubesmanager/backup_utils.py
+%{python3_sitelib}/qubesmanager/firewall.py
+%{python3_sitelib}/qubesmanager/global_settings.py
+%{python3_sitelib}/qubesmanager/multiselectwidget.py
+%{python3_sitelib}/qubesmanager/restore.py
+%{python3_sitelib}/qubesmanager/settings.py
+%{python3_sitelib}/qubesmanager/log_dialog.py
+%{python3_sitelib}/qubesmanager/about.py
+%{python3_sitelib}/qubesmanager/releasenotes.py
+%{python3_sitelib}/qubesmanager/informationnotes.py
+%{python3_sitelib}/qubesmanager/networknotes.py
+%{python3_sitelib}/qubesmanager/create_new_vm.py
+%{python3_sitelib}/qubesmanager/thread_monitor.py
+%{python3_sitelib}/qubesmanager/resources_rc.py
+%{python3_sitelib}/qubesmanager/qvm_net.py
+%{python3_sitelib}/qubesmanager/ui_backupdlg.py
+%{python3_sitelib}/qubesmanager/ui_globalsettingsdlg.py
+%{python3_sitelib}/qubesmanager/ui_mainwindow.py
+%{python3_sitelib}/qubesmanager/ui_multiselectwidget.py
+%{python3_sitelib}/qubesmanager/ui_newappvmdlg.py
+%{python3_sitelib}/qubesmanager/ui_newfwruledlg.py
+%{python3_sitelib}/qubesmanager/ui_restoredlg.py
+%{python3_sitelib}/qubesmanager/ui_settingsdlg.py
+%{python3_sitelib}/qubesmanager/ui_logdlg.py
+%{python3_sitelib}/qubesmanager/ui_about.py
+%{python3_sitelib}/qubesmanager/ui_releasenotes.py
+%{python3_sitelib}/qubesmanager/ui_informationnotes.py
+%{python3_sitelib}/qubesmanager/ui_networknotes.py
+%{python3_sitelib}/qubesmanager/i18n/qubesmanager_*.qm
 /usr/share/applications/qubes-manager.desktop
 /etc/xdg/autostart/qubes-manager.desktop
 /etc/dbus-1/system.d/org.qubesos.QubesManager.conf


### PR DESCRIPTION
updated globalsettings window with qubes 4.0 API, updated qubesmanager to compile under python3.

notes: qvm_net.py has been moved to a weird new location; to run globalsettings window use:
`python3 -m qubesmanager.global_settings`