### PR TITLE
Rename NetVM to Networking in vm-settings

### DIFF
--- a/qubesmanager/utils.py
+++ b/qubesmanager/utils.py
@@ -81,7 +81,7 @@ def prepare_choice(widget, holder, propname, choice, default,
                 str(default) if default is not None else 'none')
         # N+1: explicit None
         elif item is None:
-            text = 'none'
+            text = '(none)'
         # 1..N: choices
         else:
             text = str(item)

--- a/ui/settingsdlg.ui
+++ b/ui/settingsdlg.ui
@@ -291,7 +291,7 @@
             <item row="2" column="0">
              <widget class="QLabel" name="label_18">
               <property name="text">
-               <string>NetVM:</string>
+               <string>Networking:</string>
               </property>
               <property name="buddy">
                <cstring>netVM</cstring>


### PR DESCRIPTION
Renamed "NetVM" to "Networking" and to clear up any possible
misunderstanding, renamed "none" to "(none)" in the appropriate dropdown.

Fixes QubesOS/qubes-issues#1763