### PR TITLE
Add handling for virt_mode including PVH mode

### DIFF
--- a/ui/settingsdlg.ui
+++ b/ui/settingsdlg.ui
@@ -409,7 +409,7 @@
               <property name="fieldGrowthPolicy">
                <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
               </property>
-              <item row="0" column="0">
+              <item row="0" column="0" rowspan="2">
                <widget class="QLabel" name="label_19">
                 <property name="text">
                  <string>Kernel:</string>
@@ -422,14 +422,31 @@
               <item row="0" column="1">
                <widget class="QComboBox" name="kernel"/>
               </item>
-              <item row="1" column="0">
+              <item row="1" column="1">
+               <widget class="QLabel" name="pvh_kernel_version_warning">
+                <property name="font">
+                 <font>
+                  <weight>75</weight>
+                  <italic>true</italic>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>PVH mode requires Linux 4.11 or newer.</string>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
                <widget class="QLabel" name="label_20">
                 <property name="text">
                  <string>Kernel opts:</string>
                 </property>
                </widget>
               </item>
-              <item row="1" column="1">
+              <item row="2" column="1">
                <widget class="QLabel" name="kernel_opts">
                 <property name="font">
                  <font>
@@ -439,6 +456,87 @@
                 </property>
                 <property name="text">
                  <string>[]</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="2" column="1" rowspan="2" colspan="2">
+          <layout class="QVBoxLayout" name="verticalLayout_7">
+           <property name="sizeConstraint">
+            <enum>QLayout::SetDefaultConstraint</enum>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QGroupBox" name="virt_groupbox">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="title">
+              <string>Virtualization</string>
+             </property>
+             <layout class="QFormLayout" name="formLayout_10">
+              <property name="fieldGrowthPolicy">
+               <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+              </property>
+              <item row="0" column="0" rowspan="3">
+               <widget class="QLabel" name="label_27">
+                <property name="text">
+                 <string>Mode:</string>
+                </property>
+                <property name="buddy">
+                 <cstring>virt_mode</cstring>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QComboBox" name="virt_mode"/>
+              </item>
+              <item row="1" column="1">
+               <widget class="QLabel" name="pv_warning">
+                <property name="font">
+                 <font>
+                  <weight>75</weight>
+                  <italic>true</italic>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true">color:rgb(255, 0, 0)</string>
+                </property>
+                <property name="text">
+                 <string>Using PV mode exposes more hypervisor attack surface!</string>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QLabel" name="pvh_mode_hidden">
+                <property name="font">
+                 <font>
+                  <weight>75</weight>
+                  <italic>true</italic>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>PVH mode is hidden since it doesn't support PCI passthrough.</string>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
                 </property>
                </widget>
               </item>
@@ -891,6 +989,20 @@
              </property>
              <property name="text">
               <string>To modify PCI devices you have to turn off the VM.</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="pvh_dont_support_devs">
+             <property name="font">
+              <font>
+               <weight>75</weight>
+               <italic>true</italic>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Currently PVH VMs don't support PCI passthrough. Select another virtualization mode if you want to add PCI devices</string>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
Somebody should review this from a UX perspective.

AFAICS there's no way to get the default value of a VM property. So I hard coded the default value for `virt_mode`.