### PR TITLE
Firewall settings

### DIFF
--- a/ui/newfwruledlg.ui
+++ b/ui/newfwruledlg.ui
@@ -31,10 +31,22 @@
      <property name="verticalSpacing">
       <number>6</number>
      </property>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label">
+     <item row="2" column="2">
+      <widget class="QRadioButton" name="udp_radio">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="text">
-        <string>Protocol</string>
+        <string>UDP</string>
        </property>
       </widget>
      </item>
@@ -45,13 +57,6 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1" colspan="3">
-      <widget class="QComboBox" name="serviceComboBox">
-       <property name="editable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
@@ -59,8 +64,40 @@
        </property>
       </widget>
      </item>
+     <item row="2" column="3">
+      <widget class="QRadioButton" name="any_radio">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>71</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string> Any   </string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
      <item row="0" column="1" colspan="3">
       <widget class="QComboBox" name="addressComboBox">
+       <property name="editable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1" colspan="3">
+      <widget class="QComboBox" name="serviceComboBox">
        <property name="editable">
         <bool>true</bool>
        </property>
@@ -85,44 +122,10 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="2">
-      <widget class="QRadioButton" name="udp_radio">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label">
        <property name="text">
-        <string>UDP</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="3">
-      <widget class="QRadioButton" name="any_radio">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>71</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string> Any   </string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
+        <string>Protocol</string>
        </property>
       </widget>
      </item>

--- a/ui/settingsdlg.ui
+++ b/ui/settingsdlg.ui
@@ -29,7 +29,7 @@
         <locale language="English" country="UnitedStates"/>
        </property>
        <property name="currentIndex">
-        <number>1</number>
+        <number>2</number>
        </property>
        <widget class="QWidget" name="basic_tab">
         <property name="locale">
@@ -655,48 +655,101 @@
          <string>Firewall rules</string>
         </attribute>
         <layout class="QGridLayout" name="gridLayout_8">
-         <item row="0" column="0">
-          <widget class="QRadioButton" name="policyAllowRadioButton">
-           <property name="text">
-            <string>Allow network access except...</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QCheckBox" name="icmpCheckBox">
-           <property name="minimumSize">
-            <size>
-             <width>323</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>Allow ICMP traffic</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
          <item row="1" column="0">
-          <widget class="QRadioButton" name="policyDenyRadioButton">
-           <property name="text">
-            <string>Deny network access except...</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QCheckBox" name="dnsCheckBox">
-           <property name="text">
-            <string>Allow DNS queries</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
+          <layout class="QHBoxLayout" name="horizontalLayout_5">
+           <item>
+            <widget class="QRadioButton" name="policyAllowRadioButton">
+             <property name="text">
+              <string>Allow all outgoing Internet connections</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QRadioButton" name="policyDenyRadioButton">
+             <property name="text">
+              <string>Limit outgoing Internet connections to ...</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
          <item row="3" column="0" colspan="2">
-          <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <widget class="Line" name="line">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0" colspan="2">
+          <widget class="QLabel" name="label_22">
+           <property name="text">
+            <string>NOTE:  To block all network access, set Networking to (none) on the Basic settings tab. This tab provides a very simplified firewall configuration. All DNS requests and ICMP (pings) will be allowed. For more granular control, use the command line tool qvm-firewall.</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="firewalRulesLabel">
+           <property name="text">
+            <string>List of allowed (whitelisted) addresses:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QWidget" name="tempFullAccessWidget" native="true">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_6">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item row="1" column="0">
+             <widget class="QCheckBox" name="tempFullAccess">
+              <property name="text">
+               <string>Allow full access for </string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QSpinBox" name="tempFullAccessTime">
+              <property name="suffix">
+               <string> min</string>
+              </property>
+              <property name="value">
+               <number>5</number>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="2">
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item row="5" column="0" colspan="2">
+          <layout class="QHBoxLayout" name="firewallRulesLayout">
            <property name="sizeConstraint">
             <enum>QLayout::SetMaximumSize</enum>
            </property>
@@ -805,46 +858,55 @@
            </item>
           </layout>
          </item>
-         <item row="2" column="1">
-          <widget class="QCheckBox" name="yumproxyCheckBox">
+         <item row="0" column="0">
+          <widget class="QLabel" name="firewallModifiedOutsidelabel">
+           <property name="palette">
+            <palette>
+             <active>
+              <colorrole role="WindowText">
+               <brush brushstyle="SolidPattern">
+                <color alpha="255">
+                 <red>255</red>
+                 <green>0</green>
+                 <blue>0</blue>
+                </color>
+               </brush>
+              </colorrole>
+             </active>
+             <inactive>
+              <colorrole role="WindowText">
+               <brush brushstyle="SolidPattern">
+                <color alpha="255">
+                 <red>255</red>
+                 <green>0</green>
+                 <blue>0</blue>
+                </color>
+               </brush>
+              </colorrole>
+             </inactive>
+             <disabled>
+              <colorrole role="WindowText">
+               <brush brushstyle="SolidPattern">
+                <color alpha="255">
+                 <red>139</red>
+                 <green>142</green>
+                 <blue>142</blue>
+                </color>
+               </brush>
+              </colorrole>
+             </disabled>
+            </palette>
+           </property>
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <italic>true</italic>
+             <bold>true</bold>
+            </font>
+           </property>
            <property name="text">
-            <string>Allow connections to Updates Proxy</string>
+            <string>Firewall has been modified manually - please use qvm-firewall for any further configuration.</string>
            </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QWidget" name="tempFullAccessWidget" native="true">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <layout class="QGridLayout" name="gridLayout_6">
-            <property name="leftMargin">
-             <number>0</number>
-            </property>
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
-             <number>0</number>
-            </property>
-            <item row="0" column="0">
-             <widget class="QCheckBox" name="tempFullAccess">
-              <property name="text">
-               <string>Allow full access for </string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QSpinBox" name="tempFullAccessTime">
-              <property name="suffix">
-               <string> min</string>
-              </property>
-              <property name="value">
-               <number>5</number>
-              </property>
-             </widget>
-            </item>
-           </layout>
           </widget>
          </item>
         </layout>
@@ -1035,11 +1097,6 @@
   <tabstop>vcpus</tabstop>
   <tabstop>include_in_balancing</tabstop>
   <tabstop>kernel</tabstop>
-  <tabstop>policyAllowRadioButton</tabstop>
-  <tabstop>policyDenyRadioButton</tabstop>
-  <tabstop>icmpCheckBox</tabstop>
-  <tabstop>dnsCheckBox</tabstop>
-  <tabstop>yumproxyCheckBox</tabstop>
   <tabstop>newRuleButton</tabstop>
   <tabstop>rulesTreeView</tabstop>
   <tabstop>editRuleButton</tabstop>


### PR DESCRIPTION
VM Settings - Firewall Tab modifications

* changed underlying code to use Qubes 4.0 firewall API
* changed tab to handle only two basic situations: allow all outgoing connections and block all, with an optional whitelist and an option to allow all for a limited period of time
* removed 'allow DNS' and 'allow ICMP' checkboxes