### PR TITLE
Fixed bug with firewall GUI settings

### DIFF
--- a/qubesmanager/firewall.py
+++ b/qubesmanager/firewall.py
@@ -244,7 +244,7 @@ class QubesFirewallRulesModel(QtCore.QAbstractItemModel):
                 allow_dns = True
                 continue
 
-            if rule.proto == icmp_rule:
+            if rule == icmp_rule:
                 allow_icmp = True
                 continue
 


### PR DESCRIPTION
Fixed bug that led to correct firewall configuration not being
recognized by GUI VM Settings.

fixes QubesOS/qubes-issues#3289