### PR TITLE
Enabled Firewall config without a netvm

### DIFF
--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -79,9 +79,6 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
 
         self.tabWidget.currentChanged.connect(self.current_tab_changed)
 
-        self.tabWidget.setTabEnabled(self.tabs_indices["firewall"],
-                            vm.netvm is not None and not vm.provides_network)
-
         ###### basic tab
         self.__init_basic_tab__()
         self.rename_vm_button.clicked.connect(self.rename_vm)
@@ -223,13 +220,26 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
     def current_tab_changed(self, idx):
         if idx == self.tabs_indices["firewall"]:
             netvm = self.vm.netvm
+            self.no_netvm_label.setVisible(netvm is None)
+            self.netvm_no_firewall_label.setVisible(
+                netvm is not None and
+                not netvm.features.check_with_template('qubes-firewall', False))
+            if netvm is None:
+                QtGui.QMessageBox.warning(
+                    None,
+                    self.tr("Qube configuration problem!"),
+                    self.tr('This qube has networking disabled '
+                            '(Basic -> Networking) - network will be disabled. '
+                            'If you want to use firewall, '
+                            'please enable networking.')
+                )
             if netvm is not None and \
                     not netvm.features.check_with_template(
                         'qubes-firewall',
                         False):
                 QtGui.QMessageBox.warning(
                     None,
-                    self.tr("VM configuration problem!"),
+                    self.tr("Qube configuration problem!"),
                     self.tr("The '{vm}' AppVM is network connected to "
                         "'{netvm}', which does not support firewall!<br/>"
                         "You may edit the '{vm}' VM firewall rules, but these "

--- a/ui/settingsdlg.ui
+++ b/ui/settingsdlg.ui
@@ -29,7 +29,7 @@
         <locale language="English" country="UnitedStates"/>
        </property>
        <property name="currentIndex">
-        <number>1</number>
+        <number>2</number>
        </property>
        <widget class="QWidget" name="basic_tab">
         <property name="locale">
@@ -675,7 +675,7 @@ border-width: 1px;</string>
          <string>Firewall rules</string>
         </attribute>
         <layout class="QGridLayout" name="gridLayout_8">
-         <item row="1" column="0">
+         <item row="3" column="0">
           <layout class="QHBoxLayout" name="horizontalLayout_5">
            <item>
             <widget class="QRadioButton" name="policy_allow_radio_button">
@@ -693,14 +693,14 @@ border-width: 1px;</string>
            </item>
           </layout>
          </item>
-         <item row="3" column="0" colspan="2">
+         <item row="5" column="0" colspan="2">
           <widget class="Line" name="line">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
           </widget>
          </item>
-         <item row="7" column="0" colspan="2">
+         <item row="9" column="0" colspan="2">
           <widget class="QLabel" name="label_22">
            <property name="text">
             <string>NOTE:  To block all network access, set Networking to (none) on the Basic settings tab. This tab provides a very simplified firewall configuration. All DNS requests and ICMP (pings) will be allowed. For more granular control, use the command line tool qvm-firewall.</string>
@@ -713,14 +713,14 @@ border-width: 1px;</string>
            </property>
           </widget>
          </item>
-         <item row="4" column="0">
+         <item row="6" column="0">
           <widget class="QLabel" name="firewal_rules_label">
            <property name="text">
             <string>List of allowed (whitelisted) addresses:</string>
            </property>
           </widget>
          </item>
-         <item row="6" column="0">
+         <item row="8" column="0">
           <widget class="QWidget" name="tempFullAccessWidget" native="true">
            <property name="enabled">
             <bool>true</bool>
@@ -768,7 +768,7 @@ border-width: 1px;</string>
            </layout>
           </widget>
          </item>
-         <item row="5" column="0" colspan="2">
+         <item row="7" column="0" colspan="2">
           <layout class="QHBoxLayout" name="firewallRulesLayout">
            <property name="sizeConstraint">
             <enum>QLayout::SetMaximumSize</enum>
@@ -878,7 +878,7 @@ border-width: 1px;</string>
            </item>
           </layout>
          </item>
-         <item row="0" column="0">
+         <item row="2" column="0">
           <widget class="QLabel" name="firewall_modified_outside_label">
            <property name="palette">
             <palette>
@@ -926,6 +926,111 @@ border-width: 1px;</string>
            </property>
            <property name="text">
             <string>Firewall has been modified manually - please use qvm-firewall for any further configuration.</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="no_netvm_label">
+           <property name="palette">
+            <palette>
+             <active>
+              <colorrole role="WindowText">
+               <brush brushstyle="SolidPattern">
+                <color alpha="255">
+                 <red>255</red>
+                 <green>0</green>
+                 <blue>0</blue>
+                </color>
+               </brush>
+              </colorrole>
+             </active>
+             <inactive>
+              <colorrole role="WindowText">
+               <brush brushstyle="SolidPattern">
+                <color alpha="255">
+                 <red>255</red>
+                 <green>0</green>
+                 <blue>0</blue>
+                </color>
+               </brush>
+              </colorrole>
+             </inactive>
+             <disabled>
+              <colorrole role="WindowText">
+               <brush brushstyle="SolidPattern">
+                <color alpha="255">
+                 <red>139</red>
+                 <green>142</green>
+                 <blue>142</blue>
+                </color>
+               </brush>
+              </colorrole>
+             </disabled>
+            </palette>
+           </property>
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <italic>true</italic>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>This qube has no networking - it will not have any network access anyway.</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="netvm_no_firewall_label">
+           <property name="palette">
+            <palette>
+             <active>
+              <colorrole role="WindowText">
+               <brush brushstyle="SolidPattern">
+                <color alpha="255">
+                 <red>255</red>
+                 <green>0</green>
+                 <blue>0</blue>
+                </color>
+               </brush>
+              </colorrole>
+             </active>
+             <inactive>
+              <colorrole role="WindowText">
+               <brush brushstyle="SolidPattern">
+                <color alpha="255">
+                 <red>255</red>
+                 <green>0</green>
+                 <blue>0</blue>
+                </color>
+               </brush>
+              </colorrole>
+             </inactive>
+             <disabled>
+              <colorrole role="WindowText">
+               <brush brushstyle="SolidPattern">
+                <color alpha="255">
+                 <red>139</red>
+                 <green>142</green>
+                 <blue>142</blue>
+                </color>
+               </brush>
+              </colorrole>
+             </disabled>
+            </palette>
+           </property>
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <italic>true</italic>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Networking qube does not support 'qubes-firewall' - firewall restrictions will not be applied.</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
Enabled Firewall tab even when there's no working netvm or the netvm
doesn't support qubes-firewall. An appropriate warning label and message
are shown in both cases.

fixes QubesOS/qubes-issues#3290