### PR TITLE
 Added 'configure no strict reset for PCI devices' button 

### DIFF
--- a/qubesmanager/device_list.py
+++ b/qubesmanager/device_list.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python3
+#
+# The Qubes OS Project, http://www.qubes-os.org
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+from . import ui_devicelist  # pylint: disable=no-name-in-module
+from PyQt4 import QtGui, QtCore  # pylint: disable=import-error
+
+
+class PCIDeviceListWindow(ui_devicelist.Ui_Dialog, QtGui.QDialog):
+    def __init__(self, vm, qapp, dev_list, parent=None):
+        super(PCIDeviceListWindow, self).__init__(parent)
+
+        self.vm = vm
+        self.qapp = qapp
+        self.dev_list = dev_list
+
+        self.setupUi(self)
+
+        self.connect(
+            self.buttonBox, QtCore.SIGNAL("accepted()"), self.save_and_apply)
+        self.connect(
+            self.buttonBox, QtCore.SIGNAL("rejected()"), self.reject)
+
+        self.fill_device_list()
+
+    def fill_device_list(self):
+        self.device_list.clear()
+
+        pci_devices = [ass.ident.replace('_', ':')
+                       for ass in self.vm.devices['pci'].assignments()]
+
+        for i in range(self.dev_list.selected_list.count()):
+            text = self.dev_list.selected_list.item(i).text()
+            ident = self.dev_list.selected_list.item(i).ident
+            if ident in pci_devices:
+                self.device_list.addItem(text)
+
+    def reject(self):
+        self.done(0)
+
+    def save_and_apply(self):
+        self.done(0)
+
+    def show(self):
+        super(PCIDeviceListWindow, self).show()
+        self.fill_device_list()

--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -701,17 +701,16 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
                             break
                     if current_assignment is None:
                         # it would be very weird if this happened
+                        msg.append(self.tr("Error re-assigning device ") +
+                                   ident)
                         break
+
                     self.vm.devices['pci'].detach(current_assignment)
 
-                    options = {}
-                    if ident in self.new_strict_reset_list:
-                        options['no-strict-reset'] = True
-                    new_assignment = devices.DeviceAssignment(
-                        self.vm.app.domains['dom0'],
-                        ident.replace(':', '_'),
-                        persistent=True, options=options)
-                    self.vm.devices['pci'].attach(new_assignment)
+                    current_assignment.options['no-strict-reset'] = \
+                        (ident in self.new_strict_reset_list)
+
+                    self.vm.devices['pci'].attach(current_assignment)
 
             for ass in self.vm.devices['pci'].assignments(persistent=True):
                 if ass.ident.replace('_', ':') not in new:
@@ -751,8 +750,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
 
     def define_strict_reset_devices(self):
         for assignment in self.vm.devices['pci'].assignments():
-            if 'no-strict-reset' in assignment.options and \
-                    assignment.options['no-strict-reset']:
+            if assignment.options.get('no-strict-reset', False):
                 self.current_strict_reset_list.append(
                     assignment.ident.replace('_', ':'))
         self.new_strict_reset_list = self.current_strict_reset_list.copy()

--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -703,7 +703,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
                         # it would be very weird if this happened
                         msg.append(self.tr("Error re-assigning device ") +
                                    ident)
-                        break
+                        continue
 
                     self.vm.devices['pci'].detach(current_assignment)
 

--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 #
 # The Qubes OS Project, http://www.qubes-os.org
 #
@@ -43,6 +43,7 @@ from . import firewall
 from PyQt4 import QtCore, QtGui  # pylint: disable=import-error
 
 from . import ui_settingsdlg  #pylint: disable=no-name-in-module
+
 
 # pylint: disable=too-many-instance-attributes
 class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):

--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -42,7 +42,7 @@ from .appmenu_select import AppmenuSelectManager
 from . import firewall
 from PyQt4 import QtCore, QtGui  # pylint: disable=import-error
 
-from . import ui_settingsdlg  #pylint: disable=no-name-in-module
+from . import ui_settingsdlg  # pylint: disable=no-name-in-module
 
 
 # pylint: disable=too-many-instance-attributes
@@ -140,7 +140,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
     def reject(self):
         self.done(0)
 
-    #needed not to close the dialog before applying changes
+    # needed not to close the dialog before applying changes
     def accept(self):
         pass
 
@@ -278,8 +278,8 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
         self.delete_vm_button.setEnabled(not self.vm.is_running())
 
         if self.vm.is_running():
-            self.delete_vm_button.setText(self.tr('Delete VM '
-                                            '(cannot delete a running VM)'))
+            self.delete_vm_button.setText(
+                self.tr('Delete VM (cannot delete a running VM)'))
 
         if self.vm.qid == 0:
             self.vmlabel.setVisible(False)
@@ -325,13 +325,13 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
         except AttributeError:
             self.autostart_vm.setVisible(False)
 
-        #type
+        # type
         self.type_label.setText(self.vm.klass)
 
-        #installed by rpm
+        # installed by rpm
         self.rpm_label.setText('Yes' if self.vm.installed_by_rpm else 'No')
 
-        #networking info
+        # networking info
         if self.vm.netvm:
             self.networking_groupbox.setEnabled(True)
             self.ip_label.setText(self.vm.ip or "none")
@@ -340,7 +340,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
         else:
             self.networking_groupbox.setEnabled(False)
 
-        #max priv storage
+        # max priv storage
         self.priv_img_size = self.vm.volumes['private'].size // 1024**2
         self.max_priv_storage.setMinimum(self.priv_img_size)
         self.max_priv_storage.setValue(self.priv_img_size)
@@ -354,7 +354,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
     def __apply_basic_tab__(self):
         msg = []
 
-        #vm label changed
+        # vm label changed
         try:
             if self.vmlabel.isVisible():
                 if self.vmlabel.currentIndex() != self.label_idx:
@@ -363,7 +363,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
         except qubesadmin.exc.QubesException as ex:
             msg.append(str(ex))
 
-        #vm template changed
+        # vm template changed
         try:
             if self.template_name.currentIndex() != self.template_idx:
                 self.vm.template = \
@@ -371,14 +371,14 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
         except qubesadmin.exc.QubesException as ex:
             msg.append(str(ex))
 
-        #vm netvm changed
+        # vm netvm changed
         try:
             if self.netVM.currentIndex() != self.netvm_idx:
                 self.vm.netvm = self.netvm_list[self.netVM.currentIndex()]
         except qubesadmin.exc.QubesException as ex:
             msg.append(str(ex))
 
-        #include in backups
+        # include in backups
         try:
             if self.vm.include_in_backups != \
                     self.include_in_backups.isChecked():
@@ -386,7 +386,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
         except qubesadmin.exc.QubesException as ex:
             msg.append(str(ex))
 
-        #run_in_debug_mode
+        # run_in_debug_mode
         try:
             if self.run_in_debug_mode.isVisible():
                 if self.vm.debug != self.run_in_debug_mode.isChecked():
@@ -394,7 +394,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
         except qubesadmin.exc.QubesException as ex:
             msg.append(str(ex))
 
-        #autostart_vm
+        # autostart_vm
         try:
             if self.autostart_vm.isVisible():
                 if self.vm.autostart != self.autostart_vm.isChecked():
@@ -402,7 +402,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
         except qubesadmin.exc.QubesException as ex:
             msg.append(str(ex))
 
-        #max priv storage
+        # max priv storage
         priv_size = self.max_priv_storage.value()
         if self.priv_img_size != priv_size:
             try:
@@ -410,7 +410,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
             except qubesadmin.exc.QubesException as ex:
                 msg.append(str(ex))
 
-        #max sys storage
+        # max sys storage
         sys_size = self.root_resize.value()
         if self.root_img_size != sys_size:
             try:
@@ -419,7 +419,6 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
                 msg.append(str(ex))
 
         return msg
-
 
     def check_mem_changes(self):
         if self.max_mem_size.value() < self.init_mem.value():
@@ -453,10 +452,9 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
 
         if not t_monitor.success:
             QtGui.QMessageBox.warning(None,
-                                         self.tr("Error!"),
-                                         self.tr("ERROR: {}").format(
-                                    t_monitor.error_msg))
-
+                                      self.tr("Error!"),
+                                      self.tr("ERROR: {}").format(
+                                          t_monitor.error_msg))
 
     def _rename_vm(self, t_monitor, name):
         try:
@@ -469,7 +467,6 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
             t_monitor.set_error_msg(repr(ex))
 
         t_monitor.set_finished()
-
 
     def rename_vm(self):
 
@@ -499,10 +496,9 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
             self,
             self.tr('Delete VM'),
             self.tr('Are you absolutely sure you want to delete this VM? '
-                      '<br/> All VM settings and data will be irrevocably'
-                      ' deleted. <br/> If you are sure, please enter this '
-                      'VM\'s name below.'))
-
+                    '<br/> All VM settings and data will be irrevocably'
+                    ' deleted. <br/> If you are sure, please enter this '
+                    'VM\'s name below.'))
 
         if ok and answer == self.vm.name:
             self._run_in_thread(self._remove_vm)
@@ -543,7 +539,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
 
     def __init_advanced_tab__(self):
 
-        #mem/cpu
+        # mem/cpu
 #       qubes_memory = QubesHost().memory_total/1024
 
         self.init_mem.setValue(int(self.vm.memory))
@@ -561,7 +557,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
             bool(self.vm.features.get('service.meminfo-writer', True)))
         self.max_mem_size.setEnabled(self.include_in_balancing.isChecked())
 
-        #in case VM is HVM
+        # in case VM is HVM
         if hasattr(self.vm, "kernel"):
             self.kernel_groupbox.setVisible(True)
             self.kernel_list, self.kernel_idx = utils.prepare_kernel_choice(
@@ -588,7 +584,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
     def __apply_advanced_tab__(self):
         msg = []
 
-        #mem/cpu
+        # mem/cpu
         try:
             if self.init_mem.value() != int(self.vm.memory):
                 self.vm.memory = self.init_mem.value()
@@ -601,9 +597,9 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
         except qubesadmin.exc.QubesException as ex:
             msg.append(str(ex))
 
-        #include_in_memory_balancing applied in services tab
+        # include_in_memory_balancing applied in services tab
 
-        #in case VM is not Linux
+        # in case VM is not Linux
         if hasattr(self.vm, "kernel") and self.kernel_groupbox.isVisible():
             try:
                 if self.kernel.currentIndex() != self.kernel_idx:
@@ -612,7 +608,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
             except qubesadmin.exc.QubesException as ex:
                 msg.append(str(ex))
 
-        #vm default_dispvm changed
+        # vm default_dispvm changed
         try:
             if self.default_dispvm.currentIndex() != self.default_dispvm_idx:
                 self.vm.default_dispvm = \
@@ -644,7 +640,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
                 self.ident = ident
 
         persistent = [ass.ident.replace('_', ':')
-            for ass in self.vm.devices['pci'].persistent()]
+                      for ass in self.vm.devices['pci'].persistent()]
 
         for name, ident in devs:
             if ident in persistent:
@@ -669,16 +665,15 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
             self.dev_list.setEnabled(True)
             self.turn_off_vm_to_modify_devs.setVisible(False)
 
-
     def __apply_devices_tab__(self):
         msg = []
 
         try:
             old = [ass.ident.replace('_', ':')
-                for ass in self.vm.devices['pci'].persistent()]
+                   for ass in self.vm.devices['pci'].persistent()]
 
             new = [self.dev_list.selected_list.item(i).ident
-                    for i in range(self.dev_list.selected_list.count())]
+                   for i in range(self.dev_list.selected_list.count())]
             for ident in new:
                 if ident not in old:
                     ass = devices.DeviceAssignment(
@@ -774,7 +769,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
             service = feature[len('service.'):]
             item = QtGui.QListWidgetItem(service)
             item.setCheckState(ui_settingsdlg.QtCore.Qt.Checked
-                if self.vm.features[feature]
+                               if self.vm.features[feature]
                                else ui_settingsdlg.QtCore.Qt.Unchecked)
             self.services_list.addItem(item)
             self.new_srv_dict[service] = self.vm.features[feature]
@@ -815,7 +810,6 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
         item = self.services_list.takeItem(row)
         del self.new_srv_dict[str(item.text())]
 
-
     def services_item_clicked(self, item):
         if str(item.text()) == 'meminfo-writer':
             if item.checkState() == ui_settingsdlg.QtCore.Qt.Checked:
@@ -824,7 +818,6 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
             elif item.checkState() == ui_settingsdlg.QtCore.Qt.Unchecked:
                 if self.include_in_balancing.isChecked():
                     self.include_in_balancing.setChecked(False)
-
 
     def __apply_services_tab__(self):
         msg = []
@@ -861,9 +854,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
 
         return msg
 
-
     ######### firewall tab related
-
     def set_fw_model(self, model):
         self.fw_model = model
         self.rulesTreeView.setModel(model)
@@ -942,10 +933,10 @@ def handle_exception(exc_type, exc_value, exc_traceback):
     while stacktrace:
         (filename, line, func, txt) = stacktrace.pop()
         strace += "----\n"
-        strace += "line: %s\n" %txt
-        strace += "func: %s\n" %func
-        strace += "line no.: %d\n" %line
-        strace += "file: %s\n" %filename
+        strace += "line: %s\n" % txt
+        strace += "func: %s\n" % func
+        strace += "line no.: %d\n" % line
+        strace += "file: %s\n" % filename
 
     msg_box = QtGui.QMessageBox()
     msg_box.setDetailedText(strace)
@@ -963,12 +954,13 @@ def handle_exception(exc_type, exc_value, exc_traceback):
 parser = QubesArgumentParser(vmname_nargs=1)
 
 parser.add_argument('--tab', metavar='TAB',
-    action='store',
-    choices=VMSettingsWindow.tabs_indices.keys())
+                    action='store',
+                    choices=VMSettingsWindow.tabs_indices.keys())
 
 parser.set_defaults(
     tab='basic',
 )
+
 
 def main(args=None):
     args = parser.parse_args(args)

--- a/rpm_spec/qmgr.spec
+++ b/rpm_spec/qmgr.spec
@@ -91,6 +91,7 @@ rm -rf $RPM_BUILD_ROOT
 %{python3_sitelib}/qubesmanager/qube_manager.py
 %{python3_sitelib}/qubesmanager/utils.py
 %{python3_sitelib}/qubesmanager/bootfromdevice.py
+%{python3_sitelib}/qubesmanager/device_list.py
 
 %{python3_sitelib}/qubesmanager/resources_rc.py
 
@@ -107,6 +108,7 @@ rm -rf $RPM_BUILD_ROOT
 %{python3_sitelib}/qubesmanager/ui_releasenotes.py
 %{python3_sitelib}/qubesmanager/ui_informationnotes.py
 %{python3_sitelib}/qubesmanager/ui_qubemanager.py
+%{python3_sitelib}/qubesmanager/ui_devicelist.py
 %{python3_sitelib}/qubesmanager/i18n/qubesmanager_*.qm
 %{python3_sitelib}/qubesmanager/i18n/qubesmanager_*.ts
 

--- a/ui/devicelist.ui
+++ b/ui/devicelist.ui
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Select devices</string>
+  </property>
+  <widget class="QDialogButtonBox" name="buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>260</y>
+     <width>391</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   </property>
+  </widget>
+  <widget class="QListWidget" name="device_list">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>40</y>
+     <width>391</width>
+     <height>171</height>
+    </rect>
+   </property>
+   <property name="selectionMode">
+    <enum>QAbstractItemView::MultiSelection</enum>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>391</width>
+     <height>31</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Which PCI devices should use the no strict reset option?</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_2">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>220</y>
+     <width>391</width>
+     <height>41</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <italic>true</italic>
+    </font>
+   </property>
+   <property name="text">
+    <string>Note: use this option only if &quot;unable to reset PCI device&quot; error occurs. </string>
+   </property>
+   <property name="wordWrap">
+    <bool>true</bool>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/ui/settingsdlg.ui
+++ b/ui/settingsdlg.ui
@@ -29,7 +29,7 @@
         <locale language="English" country="UnitedStates"/>
        </property>
        <property name="currentIndex">
-        <number>2</number>
+        <number>3</number>
        </property>
        <widget class="QWidget" name="basic_tab">
         <property name="locale">
@@ -1088,6 +1088,13 @@ border-width: 1px;</string>
             </widget>
            </item>
           </layout>
+         </item>
+         <item>
+          <widget class="QPushButton" name="no_strict_reset_button">
+           <property name="text">
+            <string>Configure strict reset for PCI devices</string>
+           </property>
+          </widget>
          </item>
         </layout>
        </widget>


### PR DESCRIPTION
The button is in 'devices' tab of VM settings; it allows the user to
select which devices should have 'no-strict-reset' enabled and tells
the user not to change this setting if there are no errors.
(Also, there are some minor formatting fixes, because pylint was unhappy)

fixes QubesOS/qubes-issues#3205