### PR TITLE
Typos and minor fixes

### DIFF
--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -295,7 +295,6 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
             QtGui.QHeaderView.Interactive)
         self.table.horizontalHeader().setStretchLastSection(True)
 
-
         self.table.sortItems(self.columns_indices[self.sort_by_column],
                              self.sort_order)
 
@@ -854,6 +853,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
             settings_window = settings.VMSettingsWindow(
                 vm, self.qt_app, "basic")
             settings_window.exec_()
+            self.update_table()
 
     # noinspection PyArgumentList
     @QtCore.pyqtSlot(name='on_action_appmenus_triggered')

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -291,7 +291,10 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
         self.table.setColumnWidth(self.columns_indices["Backups"], 60)
         self.table.setColumnWidth(self.columns_indices["Last backup"], 90)
 
-        self.table.horizontalHeader().setResizeMode(QtGui.QHeaderView.Fixed)
+        self.table.horizontalHeader().setResizeMode(
+            QtGui.QHeaderView.Interactive)
+        self.table.horizontalHeader().setStretchLastSection(True)
+
 
         self.table.sortItems(self.columns_indices[self.sort_by_column],
                              self.sort_order)

--- a/qubesmanager/table_widgets.py
+++ b/qubesmanager/table_widgets.py
@@ -509,7 +509,7 @@ class VmLastBackupItem(QtGui.QTableWidgetItem):
 
         if self.backup_timestamp:
             self.setText(
-                str(datetime.datetime.fromtimestamp(self.vm.backup_timestamp)))
+                str(datetime.datetime.fromtimestamp(self.backup_timestamp)))
         else:
             self.setText("")
 

--- a/qubesmanager/table_widgets.py
+++ b/qubesmanager/table_widgets.py
@@ -505,7 +505,9 @@ class VmLastBackupItem(QtGui.QTableWidgetItem):
         self.setFlags(QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled)
 
         self.vm = vm
-        if getattr(self.vm, 'backup_timestamp', None):
+        self.backup_timestamp = getattr(self.vm, 'backup_timestamp', None)
+
+        if self.backup_timestamp:
             self.setText(
                 str(datetime.datetime.fromtimestamp(self.vm.backup_timestamp)))
         else:
@@ -516,10 +518,10 @@ class VmLastBackupItem(QtGui.QTableWidgetItem):
             return True
         elif other.vm.qid == 0:
             return False
-        elif self.vm.backup_timestamp == other.vm.backup_timestamp:
+        elif self.backup_timestamp == other.backup_timestamp:
             return self.vm.name < other.vm.name
-        elif not self.vm.backup_timestamp:
+        elif not self.backup_timestamp:
             return False
-        elif not other.vm.backup_timestamp:
+        elif not other.backup_timestamp:
             return True
-        return self.vm.backup_timestamp < other.vm.backup_timestamp
+        return self.backup_timestamp < other.backup_timestamp

--- a/ui/qubemanager.ui
+++ b/ui/qubemanager.ui
@@ -380,10 +380,10 @@
      <normaloff>:/createvm.png</normaloff>:/createvm.png</iconset>
    </property>
    <property name="text">
-    <string>Create &amp;New Qube</string>
+    <string>Create &amp;new qube</string>
    </property>
    <property name="toolTip">
-    <string>Create a new Qube</string>
+    <string>Create a new qube</string>
    </property>
   </action>
   <action name="action_removevm">
@@ -395,10 +395,10 @@
      <normaloff>:/removevm.png</normaloff>:/removevm.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Delete Qube</string>
+    <string>&amp;Delete qube</string>
    </property>
    <property name="toolTip">
-    <string>Remove an existing Qube (must be stopped first)</string>
+    <string>Remove an existing qube (must be stopped first)</string>
    </property>
   </action>
   <action name="action_resumevm">
@@ -410,10 +410,10 @@
      <normaloff>:/resumevm.png</normaloff>:/resumevm.png</iconset>
    </property>
    <property name="text">
-    <string>Start/Resu&amp;me Qube</string>
+    <string>Start/Resu&amp;me qube</string>
    </property>
    <property name="toolTip">
-    <string>Start/Resume selected Qube</string>
+    <string>Start/Resume selected qube</string>
    </property>
   </action>
   <action name="action_pausevm">
@@ -425,10 +425,10 @@
      <normaloff>:/pausevm.png</normaloff>:/pausevm.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Pause Qube</string>
+    <string>&amp;Pause qube</string>
    </property>
    <property name="toolTip">
-    <string>Pause selected Qube</string>
+    <string>Pause selected qube</string>
    </property>
   </action>
   <action name="action_shutdownvm">
@@ -440,10 +440,10 @@
      <normaloff>:/shutdownvm.png</normaloff>:/shutdownvm.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Shutdown Qube</string>
+    <string>&amp;Shutdown qube</string>
    </property>
    <property name="toolTip">
-    <string>Shutdown selected Qube</string>
+    <string>Shutdown selected qube</string>
    </property>
   </action>
   <action name="action_restartvm">
@@ -455,10 +455,10 @@
      <normaloff>:/restartvm.png</normaloff>:/restartvm.png</iconset>
    </property>
    <property name="text">
-    <string>Restar&amp;t Qube</string>
+    <string>Restar&amp;t qube</string>
    </property>
    <property name="toolTip">
-    <string>Restart selected Qube</string>
+    <string>Restart selected qube</string>
    </property>
   </action>
   <action name="action_appmenus">
@@ -473,7 +473,7 @@
     <string>Add/remove app s&amp;hortcuts</string>
    </property>
    <property name="toolTip">
-    <string>Add/remove app shortcuts for this Qube</string>
+    <string>Add/remove app shortcuts for this qube</string>
    </property>
   </action>
   <action name="action_updatevm">
@@ -485,10 +485,10 @@
      <normaloff>:/updateable.png</normaloff>:/updateable.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Update Qube</string>
+    <string>&amp;Update qube</string>
    </property>
    <property name="toolTip">
-    <string>Update Qube system</string>
+    <string>Update qube system</string>
    </property>
   </action>
   <action name="action_editfwrules">
@@ -497,10 +497,10 @@
      <normaloff>:/firewall.png</normaloff>:/firewall.png</iconset>
    </property>
    <property name="text">
-    <string>Edit Qube &amp;firewall rules</string>
+    <string>Edit qube &amp;firewall rules</string>
    </property>
    <property name="toolTip">
-    <string>Edit Qube firewall rules</string>
+    <string>Edit qube firewall rules</string>
    </property>
   </action>
   <action name="action_showgraphs">
@@ -568,10 +568,10 @@
      <normaloff>:/restore.png</normaloff>:/restore.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Restore Qubes from backup</string>
+    <string>&amp;Restore qubes from backup</string>
    </property>
    <property name="toolTip">
-    <string>Restore Qubes from backup</string>
+    <string>Restore qubes from backup</string>
    </property>
   </action>
   <action name="action_backup">
@@ -580,10 +580,10 @@
      <normaloff>:/backup.png</normaloff>:/backup.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Backup Qubes</string>
+    <string>&amp;Backup qubes</string>
    </property>
    <property name="toolTip">
-    <string>Backup Qubes</string>
+    <string>Backup qubes</string>
    </property>
   </action>
   <action name="action_global_settings">
@@ -624,10 +624,10 @@
      <normaloff>:/killvm.png</normaloff>:/killvm.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Kill Qube</string>
+    <string>&amp;Kill qube</string>
    </property>
    <property name="toolTip">
-    <string>Kill selected Qube</string>
+    <string>Kill selected qube</string>
    </property>
   </action>
   <action name="action_set_keyboard_layout">
@@ -639,7 +639,7 @@
     <string>Set keyboard la&amp;yout</string>
    </property>
    <property name="toolTip">
-    <string>Set keyboard layout per Qube</string>
+    <string>Set keyboard layout per qube</string>
    </property>
   </action>
   <action name="action_vm_type">
@@ -721,7 +721,7 @@
     <string>Si&amp;ze</string>
    </property>
    <property name="toolTip">
-    <string>Size on Disk</string>
+    <string>Size on disk</string>
    </property>
   </action>
   <action name="action_run_command_in_vm">
@@ -730,10 +730,10 @@
      <normaloff>:/run-command.png</normaloff>:/run-command.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Run command in Qube</string>
+    <string>&amp;Run command in qube</string>
    </property>
    <property name="toolTip">
-    <string>Run command in the specified Qube</string>
+    <string>Run command in the specified qube</string>
    </property>
   </action>
   <action name="action_clonevm">
@@ -745,10 +745,10 @@
      <normaloff>:/templatevm.png</normaloff>:/templatevm.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Clone Qube</string>
+    <string>&amp;Clone qube</string>
    </property>
    <property name="toolTip">
-    <string>Clone Qube</string>
+    <string>Clone qube</string>
    </property>
   </action>
   <action name="action_internal">
@@ -762,7 +762,7 @@
     <string>Inte&amp;rnal</string>
    </property>
    <property name="toolTip">
-    <string>Is an internal Qube</string>
+    <string>Is an internal qube</string>
    </property>
   </action>
   <action name="action_startvm_tools_install">
@@ -774,10 +774,10 @@
      <normaloff>:/resumevm.png</normaloff>:/resumevm.png</iconset>
    </property>
    <property name="text">
-    <string>Start Qube for Window Tools installation</string>
+    <string>Start qube for Window Tools installation</string>
    </property>
    <property name="toolTip">
-    <string>Start Qube for Window Tools installation</string>
+    <string>Start qube for Window Tools installation</string>
    </property>
   </action>
   <action name="action_ip">
@@ -827,10 +827,10 @@
      <normaloff>:/outdated.png</normaloff>:/outdated.png</iconset>
    </property>
    <property name="text">
-    <string>Refresh Qube List</string>
+    <string>Refresh qube list</string>
    </property>
    <property name="toolTip">
-    <string>Refresh Qube List</string>
+    <string>Refresh qube list</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Bunch of fixes for 4.0:
- fixed 'qube' spelling in Qube Manager
- Qube Manager refreshes after settings are closed
- Qube Manager columns are resizeable and the last one stretches to fill available space