### PR TITLE
Fixed error in creating new VMs from GUI

### DIFF
--- a/qubesmanager/create_new_vm.py
+++ b/qubesmanager/create_new_vm.py
@@ -123,7 +123,7 @@ class NewVmDlg(QtGui.QDialog, Ui_NewVMDlg):
         properties['netvm'] = self.netvm_list[self.netvm.currentIndex()]
         if self.install_system.isChecked():
             properties['virt_mode'] = 'hvm'
-            properties['kernel'] = 'none'
+            properties['kernel'] = None
 
         thread_monitor = ThreadMonitor()
         thread = threading.Thread(target=self.do_create_vm,

--- a/qubesmanager/create_new_vm.py
+++ b/qubesmanager/create_new_vm.py
@@ -120,8 +120,10 @@ class NewVmDlg(QtGui.QDialog, Ui_NewVMDlg):
 
         properties = {}
         properties['provides_network'] = self.provides_network.isChecked()
-        properties['virt_mode'] = 'hvm'
         properties['netvm'] = self.netvm_list[self.netvm.currentIndex()]
+        if self.install_system.isChecked():
+            properties['virt_mode'] = 'hvm'
+            properties['kernel'] = 'none'
 
         thread_monitor = ThreadMonitor()
         thread = threading.Thread(target=self.do_create_vm,


### PR DESCRIPTION
Virt mode was forcibly set to HVM. Now, the virt mode is left as default,
unless a standalone VM with system installed from elsewhere is selected.

fixes QubesOS/qubes-issues#3515