### PR TITLE
Fixes feb2018

### DIFF
--- a/qubesmanager/global_settings.py
+++ b/qubesmanager/global_settings.py
@@ -108,31 +108,16 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
             self.default_template_vmlist[
                 self.default_template_combo.currentIndex()]
 
-
     def __init_kernel_defaults__(self):
-        kernel_list = []
-        # TODO system_path["qubes_kernels_base_dir"]
-        # idea: qubes.pools['linux-kernel'].volumes
-        for k in os.listdir('/var/lib/qubes/vm-kernels'):
-            kernel_list.append(k)
-
-        self.kernel_idx = 0
-
-        for (i, k) in enumerate(kernel_list):
-            text = k
-            if k == self.qvm_collection.default_kernel:
-                text += self.tr(" (current)")
-                self.kernel_idx = i
-            self.default_kernel_combo.insertItem(i, text)
-        self.default_kernel_combo.setCurrentIndex(self.kernel_idx)
+        self.kernels_list, self.kernels_idx = utils.prepare_kernel_choice(
+            self.default_kernel_combo, self.qvm_collection, 'default_kernel',
+            None,
+            allow_none=True
+        )
 
     def __apply_kernel_defaults__(self):
-        if self.default_kernel_combo.currentIndex() != self.kernel_idx:
-            kernel = str(self.default_kernel_combo.currentText())
-            kernel = kernel.split(' ')[0]
-
-            self.qvm_collection.default_kernel = kernel
-
+        self.qvm_collection.default_kernel = \
+            self.kernels_list[self.default_kernel_combo.currentIndex()]
 
     def __init_mem_defaults__(self):
         #qmemman settings

--- a/qubesmanager/global_settings.py
+++ b/qubesmanager/global_settings.py
@@ -60,9 +60,6 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
         self.__init_updates__()
 
     def __init_system_defaults__(self):
-        all_vms = [vm for vm in self.qvm_collection.domains
-                   if (not vm.features.get('internal', False)) and vm.qid != 0]
-
         # set up updatevm choice
         self.update_vm_vmlist, self.update_vm_idx = utils.prepare_vm_choice(
             self.update_vm_combo, self.qvm_collection, 'updatevm',
@@ -84,19 +81,14 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
                 filter_function=(lambda vm: vm.provides_network),
                 allow_none=True)
 
-        #default template
-        templates = [vm for vm in all_vms if vm.klass == 'TemplateVM']
-        self.template_idx = -1
-
-        current_template = self.qvm_collection.default_template
-        for (i, vm) in enumerate(templates):
-            text = vm.name
-            if vm is current_template:
-                self.template_idx = i
-                text += self.tr(" (current)")
-            self.default_template_combo.insertItem(i, text)
-        if current_template is not None:
-            self.default_template_combo.setCurrentIndex(self.template_idx)
+        # default template
+        self.default_template_vmlist, self.default_template_idx = \
+            utils.prepare_vm_choice(
+                self.default_template_combo,
+                self.qvm_collection, 'default_template',
+                None,
+                filter_function=(lambda vm: vm.klass == 'TemplateVM')
+            )
 
     def __apply_system_defaults__(self):
         # upatevm
@@ -111,13 +103,10 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
         self.qvm_collection.default_netvm = \
             self.default_netvm_vmlist[self.default_netvm_combo.currentIndex()]
 
-        #default template
-        if self.default_template_combo.currentIndex() != self.template_idx:
-            name = str(self.default_template_combo.currentText())
-            name = name.split(' ')[0]
-            vm = self.qvm_collection.domains[name]
-
-            self.qvm_collection.default_template = vm
+        # default template
+        self.qvm_collection.default_template = \
+            self.default_template_vmlist[
+                self.default_template_combo.currentIndex()]
 
 
     def __init_kernel_defaults__(self):

--- a/qubesmanager/global_settings.py
+++ b/qubesmanager/global_settings.py
@@ -60,29 +60,20 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
         self.__init_updates__()
 
     def __init_system_defaults__(self):
-        # updatevm and clockvm
         all_vms = [vm for vm in self.qvm_collection.domains
                    if (not vm.features.get('internal', False)) and vm.qid != 0]
 
+        # set up updatevm choice
         self.update_vm_vmlist, self.update_vm_vmidx = utils.prepare_vm_choice(
             self.update_vm_combo, self.qvm_collection, 'updatevm',
             None, allow_none=True
         )
 
-        # clockvm
-        self.clockvm_idx = -1
-
-        current_clock_vm = self.qvm_collection.clockvm
-        for (i, vm) in enumerate(all_vms):
-            text = vm.name
-            if vm is current_clock_vm:
-                self.clockvm_idx = i
-                text += self.tr(" (current)")
-            self.clock_vm_combo.insertItem(i, text)
-        self.clock_vm_combo.insertItem(len(all_vms), "none")
-        if current_clock_vm is None:
-            self.clockvm_idx = len(all_vms)
-        self.clock_vm_combo.setCurrentIndex(self.clockvm_idx)
+        # set up clockvm choice
+        self.clock_vm_vmlist, self.clock_vm_vmidx = utils.prepare_vm_choice(
+            self.clock_vm_combo, self.qvm_collection, 'clockvm',
+            None, allow_none=True
+        )
 
         # default netvm
         netvms = [vm for vm in all_vms
@@ -114,17 +105,13 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
             self.default_template_combo.setCurrentIndex(self.template_idx)
 
     def __apply_system_defaults__(self):
-        #upatevm
+        # upatevm
         self.qvm_collection.updatevm = \
             self.update_vm_vmlist[self.update_vm_combo.currentIndex()]
 
-        #clockvm
-        if self.clock_vm_combo.currentIndex() != self.clockvm_idx:
-            clockvm_name = str(self.clock_vm_combo.currentText())
-            clockvm_name = clockvm_name.split(' ')[0]
-            clockvm = self.qvm_collection.domains[clockvm_name]
-
-            self.qvm_collection.clockvm = clockvm
+        # clockvm
+        self.qvm_collection.clockvm = \
+            self.clock_vm_vmlist[self.clock_vm_combo.currentIndex()]
 
         #default netvm
         if self.default_netvm_combo.currentIndex() != self.netvm_idx:

--- a/qubesmanager/global_settings.py
+++ b/qubesmanager/global_settings.py
@@ -27,7 +27,7 @@ import traceback
 from PyQt4 import QtCore, QtGui  # pylint: disable=import-error
 
 from qubesadmin import Qubes
-from qubesadmin.utils import parse_size, updates_vms_status
+from qubesadmin.utils import parse_size
 
 from . import ui_globalsettingsdlg  # pylint: disable=no-name-in-module
 from . import utils
@@ -36,7 +36,7 @@ from configparser import ConfigParser
 
 qmemman_config_path = '/etc/qubes/qmemman.conf'
 
-
+# pylint: disable=too-many-instance-attributes
 class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
                            QtGui.QDialog):
 

--- a/qubesmanager/global_settings.py
+++ b/qubesmanager/global_settings.py
@@ -30,6 +30,7 @@ from qubesadmin import Qubes
 from qubesadmin.utils import parse_size, updates_vms_status
 
 from . import ui_globalsettingsdlg  # pylint: disable=no-name-in-module
+from . import utils
 
 from configparser import ConfigParser
 
@@ -63,19 +64,10 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
         all_vms = [vm for vm in self.qvm_collection.domains
                    if (not vm.features.get('internal', False)) and vm.qid != 0]
 
-        self.updatevm_idx = -1
-
-        current_update_vm = self.qvm_collection.updatevm
-        for (i, vm) in enumerate(all_vms):
-            text = vm.name
-            if vm is current_update_vm:
-                self.updatevm_idx = i
-                text += self.tr(" (current)")
-            self.update_vm_combo.insertItem(i, text)
-        self.update_vm_combo.insertItem(len(all_vms), "none")
-        if current_update_vm is None:
-            self.updatevm_idx = len(all_vms)
-        self.update_vm_combo.setCurrentIndex(self.updatevm_idx)
+        self.update_vm_vmlist, self.update_vm_vmidx = utils.prepare_vm_choice(
+            self.update_vm_combo, self.qvm_collection, 'updatevm',
+            None, allow_none=True
+        )
 
         # clockvm
         self.clockvm_idx = -1
@@ -123,12 +115,8 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
 
     def __apply_system_defaults__(self):
         #upatevm
-        if self.update_vm_combo.currentIndex() != self.updatevm_idx:
-            updatevm_name = str(self.update_vm_combo.currentText())
-            updatevm_name = updatevm_name.split(' ')[0]
-            updatevm = self.qvm_collection.domains[updatevm_name]
-
-            self.qvm_collection.updatevm = updatevm
+        self.qvm_collection.updatevm = \
+            self.update_vm_vmlist[self.update_vm_combo.currentIndex()]
 
         #clockvm
         if self.clock_vm_combo.currentIndex() != self.clockvm_idx:

--- a/qubesmanager/global_settings.py
+++ b/qubesmanager/global_settings.py
@@ -92,21 +92,32 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
 
     def __apply_system_defaults__(self):
         # upatevm
-        self.qvm_collection.updatevm = \
-            self.update_vm_vmlist[self.update_vm_combo.currentIndex()]
+        if self.qvm_collection.updatevm != \
+                self.update_vm_vmlist[self.update_vm_combo.currentIndex()]:
+            self.qvm_collection.updatevm = \
+                self.update_vm_vmlist[self.update_vm_combo.currentIndex()]
 
         # clockvm
-        self.qvm_collection.clockvm = \
-            self.clock_vm_vmlist[self.clock_vm_combo.currentIndex()]
+        if self.qvm_collection.clockvm !=\
+                self.clock_vm_vmlist[self.clock_vm_combo.currentIndex()]:
+            self.qvm_collection.clockvm = \
+                self.clock_vm_vmlist[self.clock_vm_combo.currentIndex()]
 
         # default netvm
-        self.qvm_collection.default_netvm = \
-            self.default_netvm_vmlist[self.default_netvm_combo.currentIndex()]
+        if self.qvm_collection.default_netvm !=\
+                self.default_netvm_vmlist[
+                    self.default_netvm_combo.currentIndex()]:
+            self.qvm_collection.default_netvm = \
+                self.default_netvm_vmlist[
+                    self.default_netvm_combo.currentIndex()]
 
         # default template
-        self.qvm_collection.default_template = \
-            self.default_template_vmlist[
-                self.default_template_combo.currentIndex()]
+        if self.qvm_collection.default_template != \
+                self.default_template_vmlist[
+                    self.default_template_combo.currentIndex()]:
+            self.qvm_collection.default_template = \
+                self.default_template_vmlist[
+                    self.default_template_combo.currentIndex()]
 
     def __init_kernel_defaults__(self):
         self.kernels_list, self.kernels_idx = utils.prepare_kernel_choice(
@@ -116,8 +127,10 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
         )
 
     def __apply_kernel_defaults__(self):
-        self.qvm_collection.default_kernel = \
-            self.kernels_list[self.default_kernel_combo.currentIndex()]
+        if self.qvm_collection.default_kernel != \
+                self.kernels_list[self.default_kernel_combo.currentIndex()]:
+            self.qvm_collection.default_kernel = \
+                self.kernels_list[self.default_kernel_combo.currentIndex()]
 
     def __init_mem_defaults__(self):
         #qmemman settings

--- a/qubesmanager/global_settings.py
+++ b/qubesmanager/global_settings.py
@@ -64,31 +64,25 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
                    if (not vm.features.get('internal', False)) and vm.qid != 0]
 
         # set up updatevm choice
-        self.update_vm_vmlist, self.update_vm_vmidx = utils.prepare_vm_choice(
+        self.update_vm_vmlist, self.update_vm_idx = utils.prepare_vm_choice(
             self.update_vm_combo, self.qvm_collection, 'updatevm',
             None, allow_none=True
         )
 
         # set up clockvm choice
-        self.clock_vm_vmlist, self.clock_vm_vmidx = utils.prepare_vm_choice(
+        self.clock_vm_vmlist, self.clock_vm_idx = utils.prepare_vm_choice(
             self.clock_vm_combo, self.qvm_collection, 'clockvm',
             None, allow_none=True
         )
 
-        # default netvm
-        netvms = [vm for vm in all_vms
-                  if getattr(vm, 'provides_network', False)]
-        self.netvm_idx = -1
-
-        current_netvm = self.qvm_collection.default_netvm
-        for (i, vm) in enumerate(netvms):
-            text = vm.name
-            if vm is current_netvm:
-                self.netvm_idx = i
-                text += self.tr(" (current)")
-            self.default_netvm_combo.insertItem(i, text)
-        if current_netvm is not None:
-            self.default_netvm_combo.setCurrentIndex(self.netvm_idx)
+        # set up default netvm
+        self.default_netvm_vmlist, self.default_netvm_idx = \
+            utils.prepare_vm_choice(
+                self.default_netvm_combo,
+                self.qvm_collection, 'default_netvm',
+                None,
+                filter_function=(lambda vm: vm.provides_network),
+                allow_none=True)
 
         #default template
         templates = [vm for vm in all_vms if vm.klass == 'TemplateVM']
@@ -113,13 +107,9 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
         self.qvm_collection.clockvm = \
             self.clock_vm_vmlist[self.clock_vm_combo.currentIndex()]
 
-        #default netvm
-        if self.default_netvm_combo.currentIndex() != self.netvm_idx:
-            name = str(self.default_netvm_combo.currentText())
-            name = name.split(' ')[0]
-            vm = self.qvm_collection.domains[name]
-
-            self.qvm_collection.default_netvm = vm
+        # default netvm
+        self.qvm_collection.default_netvm = \
+            self.default_netvm_vmlist[self.default_netvm_combo.currentIndex()]
 
         #default template
         if self.default_template_combo.currentIndex() != self.template_idx:

--- a/qubesmanager/utils.py
+++ b/qubesmanager/utils.py
@@ -33,7 +33,7 @@ def _filter_internal(vm):
 def prepare_choice(widget, holder, propname, choice, default,
         filter_function=None, *,
         icon_getter=None, allow_internal=None, allow_default=False,
-        allow_none=False, transform=None, empty_string_is_none=True):
+        allow_none=False, transform=None):
 
     # for newly created vms, set propname to None
 

--- a/qubesmanager/utils.py
+++ b/qubesmanager/utils.py
@@ -33,7 +33,7 @@ def _filter_internal(vm):
 def prepare_choice(widget, holder, propname, choice, default,
         filter_function=None, *,
         icon_getter=None, allow_internal=None, allow_default=False,
-        allow_none=False, transform=None):
+        allow_none=False, transform=None, empty_string_is_none=True):
 
     # for newly created vms, set propname to None
 

--- a/ui/globalsettingsdlg.ui
+++ b/ui/globalsettingsdlg.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>678</width>
-    <height>331</height>
+    <width>651</width>
+    <height>386</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -195,6 +195,13 @@
       <string>Updates</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
+      <item row="1" column="1">
+       <widget class="QPushButton" name="disable_updates_all">
+        <property name="text">
+         <string>Disable checking for updates for all VMs</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="0">
        <widget class="QCheckBox" name="updates_dom0">
         <property name="text">
@@ -212,6 +219,13 @@
         </property>
         <property name="text">
          <string>Check for qube updates</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QPushButton" name="enable_updates_all">
+        <property name="text">
+         <string>Enable checking for updates for all VMs</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
A bunch of minor fixes for errors discovered in testings:
- updatevm, clockvm, default netvm couldn't be set to None in global settings
- default template and kernel pickers were made completely from scratch, instead of using prepare_choice from utils
- check-dom0-updates wasn't working
- replaced check_for_updates checkbox with buttons to change state of all vms