### PR TITLE
Minor textual update for Global Settings

### DIFF
--- a/ui/globalsettingsdlg.ui
+++ b/ui/globalsettingsdlg.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>651</width>
-    <height>386</height>
+    <width>974</width>
+    <height>489</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -38,12 +38,16 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>UpdateVM:</string>
+         <string>Dom0 UpdateVM:</string>
         </property>
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QComboBox" name="update_vm_combo"/>
+       <widget class="QComboBox" name="update_vm_combo">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is updateVM ONLY for dom0; if you want to change updateVMs for other VMs, use /etc/qubes-rpc/policy/qubes.UpdatesProxy&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_2">

--- a/ui/globalsettingsdlg.ui
+++ b/ui/globalsettingsdlg.ui
@@ -45,7 +45,7 @@
       <item row="0" column="1">
        <widget class="QComboBox" name="update_vm_combo">
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is updateVM ONLY for dom0; if you want to change updateVMs for other VMs, use /etc/qubes-rpc/policy/qubes.UpdatesProxy&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>This is updateVM ONLY for dom0; if you want to change updateVMs for other VMs, use /etc/qubes-rpc/policy/qubes.UpdatesProxy</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
In lieu of bigger overhaul/processing policy files in
VM Settings, a bit of explanation for updateVM in Global
Settings and a change of name from UpdateVM to Dom0 Update VM
there. This is quick fix solution, pending a better
one when (hopefully) we get some better API for
interacting with policies.

references QubesOS/qubes-issues#3412