### PR TITLE
Check if VM needs killing before murdering it

### DIFF
--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -192,7 +192,12 @@ class VmShutdownMonitor(QtCore.QObject):
                     self.tr("Wait another {0} seconds...").format(
                         self.shutdown_time / 1000))
                 if reply == 0:
-                    vm.kill()
+                    try:
+                        vm.kill()
+                    except exc.QubesVMNotStartedError:
+                        # the VM shut down while the user was thinking about
+                        # shutting it down
+                        pass
                     self.restart_vm_if_needed()
                 else:
                     self.shutdown_started = datetime.now()

--- a/test-packages/qubesadmin/exc.py
+++ b/test-packages/qubesadmin/exc.py
@@ -4,3 +4,6 @@
 
 class QubesException(BaseException):
     pass
+
+class QubesVMNotStartedError(BaseException):
+    pass


### PR DESCRIPTION
In some cases, when the user waited some time before force-killing a VM,
it could be already dead.

fixes QubesOS/qubes-issues#3730