### PR TITLE
Tiny fix for Qube Manager params

### DIFF
--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -231,7 +231,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
                        "Last backup": 10,
                        }
 
-    def __init__(self, qubes_app, qt_app, parent=None):
+    def __init__(self, qt_app, qubes_app, parent=None):
         # pylint: disable=unused-argument
         super(VmManagerWindow, self).__init__()
         self.setupUi(self)
@@ -1199,7 +1199,7 @@ def main():
 
     qubes_app = Qubes()
 
-    manager_window = VmManagerWindow(qubes_app, qt_app)
+    manager_window = VmManagerWindow(qt_app, qubes_app)
 
     manager_window.show()
     manager_window.update_table()


### PR DESCRIPTION
Made Qube Manager params consistent with other manager
tools (first Qt, then Qubes).