### PR TITLE
Removed progress wait when updating template

### DIFF
--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -919,20 +919,6 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
         thread.daemon = True
         thread.start()
 
-        progress = QtGui.QProgressDialog(
-                self.tr(
-                    "<b>{0}</b><br>Please wait for the updater to "
-                    "launch...").format(vm.name), "", 0, 0)
-        progress.setCancelButton(None)
-        progress.setModal(True)
-        progress.show()
-
-        while not t_monitor.is_finished():
-            self.qt_app.processEvents()
-            time.sleep(0.2)
-
-        progress.hide()
-
         if vm.qid != 0:
             if not t_monitor.success:
                 QtGui.QMessageBox.warning(


### PR DESCRIPTION
Hi

I think this wait is pretty disruptive when you want to launch many updates at same time (e.g. debian-9, whonix-gw, whonix-ws). 

I tested without it some days and I had no problem. As a side effect the row is not marked as running until refreshing the manager, but this should be fixed when a DBUS event loop is enabled. Is anyone working on it?  