### PR TITLE
Fix errors when a VM is renamed or two are fast deleted.

### DIFF
--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -34,7 +34,7 @@ import threading
 from pydbus import SessionBus
 
 from qubesadmin import Qubes
-from qubesadmin import exc  # pylint: disable=no-name-in-module
+from qubesadmin import exc
 
 from PyQt4 import QtGui  # pylint: disable=import-error
 from PyQt4 import QtCore  # pylint: disable=import-error
@@ -966,7 +966,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
             # vm could be deleted on renaming
             try:
                 self.vms_in_table[vm.qid].update()
-            except exc.QubesPropertyAccessError:
+            except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
                 pass
 
 
@@ -1245,7 +1245,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
 
             self.logs_menu.setEnabled(not menu_empty)
             self.context_menu.exec_(self.table.mapToGlobal(point))
-        except exc.QubesPropertyAccessError:
+        except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
             pass
 
     @QtCore.pyqtSlot('QAction *')

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -34,7 +34,7 @@ import threading
 from pydbus import SessionBus
 
 from qubesadmin import Qubes
-from qubesadmin import exc
+from qubesadmin import exc  # pylint: disable=no-name-in-module
 
 from PyQt4 import QtGui  # pylint: disable=import-error
 from PyQt4 import QtCore  # pylint: disable=import-error

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -966,7 +966,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
             # vm could be deleted on renaming
             try:
                 self.vms_in_table[vm.qid].update()
-            except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
+            except exc.QubesPropertyAccessError:  # pylint: disable=no-member
                 pass
 
 
@@ -1245,7 +1245,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
 
             self.logs_menu.setEnabled(not menu_empty)
             self.context_menu.exec_(self.table.mapToGlobal(point))
-        except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
+        except exc.QubesPropertyAccessError:  # pylint: disable=no-member
             pass
 
     @QtCore.pyqtSlot('QAction *')

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -392,10 +392,11 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
         timer = QtCore.QTimer(self)
         timer.timeout.connect(self.check_updates)
         timer.start(1000 * 30) # 30s
+        self.check_updates()
 
     def check_updates(self):
         for vm in self.qubes_app.domains:
-            if vm.klass == 'TemplateVM':
+            if vm.klass in {'TemplateVM', 'StandaloneVM'}:
                 self.vms_in_table[vm.qid].update()
 
     def on_domain_added(self, _, domain):

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -967,7 +967,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
             # vm could be deleted on renaming
             try:
                 self.vms_in_table[vm.qid].update()
-            except exc.QubesPropertyAccessError:  # pylint: disable=no-member
+            except exc.QubesPropertyAccessError(BaseExeption):
                 pass
 
 
@@ -1246,7 +1246,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
 
             self.logs_menu.setEnabled(not menu_empty)
             self.context_menu.exec_(self.table.mapToGlobal(point))
-        except exc.QubesPropertyAccessError:  # pylint: disable=no-member
+        except exc.QubesPropertyAccessError(BaseExeption):
             pass
 
     @QtCore.pyqtSlot('QAction *')

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -403,8 +403,6 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
         self.qubes_app.domains.clear_cache()
         qid = int(domain.split('/')[-1])
 
-        self.table.setSortingEnabled(False)
-
         row_no = self.table.rowCount()
         self.table.setRowCount(row_no + 1)
 
@@ -413,7 +411,6 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
             if vm.qid == qid:
                 vm_row = VmRowInTable(vm, row_no, self.table)
                 self.vms_in_table[vm.qid] = vm_row
-                self.table.setSortingEnabled(True)
                 return
 
         # Never should reach here

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -404,6 +404,8 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
         self.qubes_app.domains.clear_cache()
         qid = int(domain.split('/')[-1])
 
+        self.table.setSortingEnabled(False)
+
         row_no = self.table.rowCount()
         self.table.setRowCount(row_no + 1)
 
@@ -412,6 +414,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
             if vm.qid == qid:
                 vm_row = VmRowInTable(vm, row_no, self.table)
                 self.vms_in_table[vm.qid] = vm_row
+                self.table.setSortingEnabled(True)
                 return
 
         # Never should reach here

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -967,7 +967,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
             # vm could be deleted on renaming
             try:
                 self.vms_in_table[vm.qid].update()
-            except exc.QubesPropertyAccessError(BaseExeption):
+            except exc.QubesPropertyAccessError:
                 pass
 
 
@@ -1246,7 +1246,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
 
             self.logs_menu.setEnabled(not menu_empty)
             self.context_menu.exec_(self.table.mapToGlobal(point))
-        except exc.QubesPropertyAccessError(BaseExeption):
+        except exc.QubesPropertyAccessError:
             pass
 
     @QtCore.pyqtSlot('QAction *')

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -415,6 +415,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
                 vm_row = VmRowInTable(vm, row_no, self.table)
                 self.vms_in_table[vm.qid] = vm_row
                 self.table.setSortingEnabled(True)
+                self.showhide_vms()
                 return
 
         # Never should reach here

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -961,7 +961,13 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
             settings_window = settings.VMSettingsWindow(
                 vm, self.qt_app, "basic")
             settings_window.exec_()
-            self.vms_in_table[vm.qid].update()
+
+            # vm could be deleted on renaming
+            try:
+                self.vms_in_table[vm.qid].update()
+            except exc.QubesPropertyAccessError:
+                pass
+
 
     # noinspection PyArgumentList
     @QtCore.pyqtSlot(name='on_action_appmenus_triggered')

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -1219,31 +1219,34 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
 
     @QtCore.pyqtSlot('const QPoint&')
     def open_context_menu(self, point):
-        vm = self.get_selected_vm()
+        try:
+            vm = self.get_selected_vm()
 
-        # logs menu
-        self.logs_menu.clear()
+            # logs menu
+            self.logs_menu.clear()
 
-        if vm.qid == 0:
-            logfiles = ["/var/log/xen/console/hypervisor.log"]
-        else:
-            logfiles = [
-                "/var/log/xen/console/guest-" + vm.name + ".log",
-                "/var/log/xen/console/guest-" + vm.name + "-dm.log",
-                "/var/log/qubes/guid." + vm.name + ".log",
-                "/var/log/qubes/qrexec." + vm.name + ".log",
-            ]
+            if vm.qid == 0:
+                logfiles = ["/var/log/xen/console/hypervisor.log"]
+            else:
+                logfiles = [
+                    "/var/log/xen/console/guest-" + vm.name + ".log",
+                    "/var/log/xen/console/guest-" + vm.name + "-dm.log",
+                    "/var/log/qubes/guid." + vm.name + ".log",
+                    "/var/log/qubes/qrexec." + vm.name + ".log",
+                ]
 
-        menu_empty = True
-        for logfile in logfiles:
-            if os.path.exists(logfile):
-                action = self.logs_menu.addAction(QtGui.QIcon(":/log.png"),
-                                                  logfile)
-                action.setData(logfile)
-                menu_empty = False
+            menu_empty = True
+            for logfile in logfiles:
+                if os.path.exists(logfile):
+                    action = self.logs_menu.addAction(QtGui.QIcon(":/log.png"),
+                                                      logfile)
+                    action.setData(logfile)
+                    menu_empty = False
 
-        self.logs_menu.setEnabled(not menu_empty)
-        self.context_menu.exec_(self.table.mapToGlobal(point))
+            self.logs_menu.setEnabled(not menu_empty)
+            self.context_menu.exec_(self.table.mapToGlobal(point))
+        except exc.QubesPropertyAccessError:
+            pass
 
     @QtCore.pyqtSlot('QAction *')
     def show_log(self, action):

--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -478,6 +478,8 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
                                       self.tr("Error!"),
                                       self.tr("ERROR: {}").format(
                                           t_monitor.error_msg))
+            return False
+        return True
 
     def _rename_vm(self, t_monitor, name):
         try:
@@ -492,15 +494,14 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
         t_monitor.set_finished()
 
     def rename_vm(self):
-
         new_vm_name, ok = QtGui.QInputDialog.getText(
             self,
             self.tr('Rename qube'),
             self.tr('New name: (WARNING: all other changes will be discarded)'))
 
         if ok:
-            self._run_in_thread(self._rename_vm, new_vm_name)
-            self.done(0)
+            if self._run_in_thread(self._rename_vm, new_vm_name):
+                self.done(0)
 
     def _remove_vm(self, t_monitor):
         try:

--- a/qubesmanager/table_widgets.py
+++ b/qubesmanager/table_widgets.py
@@ -420,7 +420,7 @@ class VmUpdateInfoWidget(QtGui.QWidget):
                         outdated_state = "outdated"
                         break
 
-        elif self.vm.klass in {'TemplateVM', 'StandaloneVM'} and \
+        if self.vm.klass in {'TemplateVM', 'StandaloneVM'} and \
                 self.vm.features.get('updates-available', False):
             outdated_state = 'update'
 

--- a/qubesmanager/table_widgets.py
+++ b/qubesmanager/table_widgets.py
@@ -24,6 +24,8 @@ from PyQt4 import QtGui  # pylint: disable=import-error
 from PyQt4 import QtCore  # pylint: disable=import-error
 # pylint: disable=too-few-public-methods
 
+from qubesadmin import exc
+
 power_order = QtCore.Qt.DescendingOrder
 update_order = QtCore.Qt.AscendingOrder
 
@@ -74,13 +76,16 @@ class VmTypeWidget(VmIconWidget):
             self.value = value
 
         def __lt__(self, other):
-            if self.vm.qid == 0:
-                return True
-            elif other.vm.qid == 0:
+            try:
+                if self.vm.qid == 0:
+                    return True
+                elif other.vm.qid == 0:
+                    return False
+                elif self.value == other.value:
+                    return self.vm.name < other.vm.name
+                return self.value < other.value
+            except exc.QubesPropertyAccessError:
                 return False
-            elif self.value == other.value:
-                return self.vm.name < other.vm.name
-            return self.value < other.value
 
     def __init__(self, vm, parent=None):
         (icon_path, tooltip) = self.get_vm_icon(vm)
@@ -120,13 +125,16 @@ class VmLabelWidget(VmIconWidget):
             self.value = value
 
         def __lt__(self, other):
-            if self.vm.qid == 0:
-                return True
-            elif other.vm.qid == 0:
+            try:
+                if self.vm.qid == 0:
+                    return True
+                elif other.vm.qid == 0:
+                    return False
+                elif self.value == other.value:
+                    return self.vm.name < other.vm.name
+                return self.value < other.value
+            except exc.QubesPropertyAccessError:
                 return False
-            elif self.value == other.value:
-                return self.vm.name < other.vm.name
-            return self.value < other.value
 
     def __init__(self, vm, parent=None):
         icon_path = self.get_vm_icon_path(vm)
@@ -149,11 +157,14 @@ class VmNameItem(QtGui.QTableWidgetItem):
         self.qid = vm.qid
 
     def __lt__(self, other):
-        if self.qid == 0:
-            return True
-        elif other.qid == 0:
+        try:
+            if self.qid == 0:
+                return True
+            elif other.qid == 0:
+                return False
+            return super(VmNameItem, self).__lt__(other)
+        except exc.QubesPropertyAccessError:
             return False
-        return super(VmNameItem, self).__lt__(other)
 
 
 class VmStatusIcon(QtGui.QLabel):
@@ -193,9 +204,12 @@ class VmInfoWidget(QtGui.QWidget):
 
         def __lt__(self, other):
             # pylint: disable=too-many-return-statements
-            if self.vm.qid == 0:
-                return True
-            elif other.vm.qid == 0:
+            try:
+                if self.vm.qid == 0:
+                    return True
+                elif other.vm.qid == 0:
+                    return False
+            except exc.QubesPropertyAccessError:
                 return False
 
             self_val = self.upd_info_item.value
@@ -278,13 +292,16 @@ class VmTemplateItem(QtGui.QTableWidgetItem):
             self.setText(self.vm.klass)
 
     def __lt__(self, other):
-        if self.vm.qid == 0:
-            return True
-        elif other.vm.qid == 0:
+        try:
+            if self.vm.qid == 0:
+                return True
+            elif other.vm.qid == 0:
+                return False
+            elif self.text() == other.text():
+                return self.vm.name < other.vm.name
+            return super(VmTemplateItem, self).__lt__(other)
+        except exc.QubesPropertyAccessError:
             return False
-        elif self.text() == other.text():
-            return self.vm.name < other.vm.name
-        return super(VmTemplateItem, self).__lt__(other)
 
 
 class VmNetvmItem(QtGui.QTableWidgetItem):
@@ -302,13 +319,16 @@ class VmNetvmItem(QtGui.QTableWidgetItem):
             self.setText(self.vm.netvm.name)
 
     def __lt__(self, other):
-        if self.vm.qid == 0:
-            return True
-        elif other.vm.qid == 0:
+        try:
+            if self.vm.qid == 0:
+                return True
+            elif other.vm.qid == 0:
+                return False
+            elif self.text() == other.text():
+                return self.vm.name < other.vm.name
+            return super(VmNetvmItem, self).__lt__(other)
+        except exc.QubesPropertyAccessError:
             return False
-        elif self.text() == other.text():
-            return self.vm.name < other.vm.name
-        return super(VmNetvmItem, self).__lt__(other)
 
 
 class VmInternalItem(QtGui.QTableWidgetItem):
@@ -325,11 +345,14 @@ class VmInternalItem(QtGui.QTableWidgetItem):
 
 
     def __lt__(self, other):
-        if self.vm.qid == 0:
-            return True
-        elif other.vm.qid == 0:
+        try:
+            if self.vm.qid == 0:
+                return True
+            elif other.vm.qid == 0:
+                return False
+            return super(VmInternalItem, self).__lt__(other)
+        except exc.QubesPropertyAccessError:
             return False
-        return super(VmInternalItem, self).__lt__(other)
 
 
 # features man qvm-features
@@ -350,13 +373,16 @@ class VmUpdateInfoWidget(QtGui.QWidget):
                 self.value = 0
 
         def __lt__(self, other):
-            if self.vm.qid == 0:
-                return True
-            elif other.vm.qid == 0:
+            try:
+                if self.vm.qid == 0:
+                    return True
+                elif other.vm.qid == 0:
+                    return False
+                elif self.value == other.value:
+                    return self.vm.name < other.vm.name
+                return self.value < other.value
+            except exc.QubesPropertyAccessError:
                 return False
-            elif self.value == other.value:
-                return self.vm.name < other.vm.name
-            return self.value < other.value
 
     def __init__(self, vm, show_text=True, parent=None):
         super(VmUpdateInfoWidget, self).__init__(parent)
@@ -457,13 +483,16 @@ class VmSizeOnDiskItem(QtGui.QTableWidgetItem):
             self.setText(str(self.value) + " MiB")
 
     def __lt__(self, other):
-        if self.vm.qid == 0:
-            return True
-        elif other.vm.qid == 0:
+        try:
+            if self.vm.qid == 0:
+                return True
+            elif other.vm.qid == 0:
+                return False
+            elif self.value == other.value:
+                return self.vm.name < other.vm.name
+            return self.value < other.value
+        except exc.QubesPropertyAccessError:
             return False
-        elif self.value == other.value:
-            return self.vm.name < other.vm.name
-        return self.value < other.value
 
 
 class VmIPItem(QtGui.QTableWidgetItem):
@@ -479,11 +508,14 @@ class VmIPItem(QtGui.QTableWidgetItem):
         self.setText(self.ip if self.ip is not None else 'n/a')
 
     def __lt__(self, other):
-        if self.vm.qid == 0:
-            return True
-        elif other.vm.qid == 0:
+        try:
+            if self.vm.qid == 0:
+                return True
+            elif other.vm.qid == 0:
+                return False
+            return super(VmIPItem, self).__lt__(other)
+        except exc.QubesPropertyAccessError:
             return False
-        return super(VmIPItem, self).__lt__(other)
 
 
 class VmIncludeInBackupsItem(QtGui.QTableWidgetItem):
@@ -501,13 +533,16 @@ class VmIncludeInBackupsItem(QtGui.QTableWidgetItem):
             self.setText("")
 
     def __lt__(self, other):
-        if self.vm.qid == 0:
-            return True
-        elif other.vm.qid == 0:
+        try:
+            if self.vm.qid == 0:
+                return True
+            elif other.vm.qid == 0:
+                return False
+            elif self.vm.include_in_backups == other.vm.include_in_backups:
+                return self.vm.name < other.vm.name
+            return self.vm.include_in_backups < other.vm.include_in_backups
+        except exc.QubesPropertyAccessError:
             return False
-        elif self.vm.include_in_backups == other.vm.include_in_backups:
-            return self.vm.name < other.vm.name
-        return self.vm.include_in_backups < other.vm.include_in_backups
 
 
 class VmLastBackupItem(QtGui.QTableWidgetItem):
@@ -528,14 +563,17 @@ class VmLastBackupItem(QtGui.QTableWidgetItem):
             self.setText("")
 
     def __lt__(self, other):
-        if self.vm.qid == 0:
-            return True
-        elif other.vm.qid == 0:
+        try:
+            if self.vm.qid == 0:
+                return True
+            elif other.vm.qid == 0:
+                return False
+            elif self.backup_timestamp == other.backup_timestamp:
+                return self.vm.name < other.vm.name
+            elif not self.backup_timestamp:
+                return False
+            elif not other.backup_timestamp:
+                return True
+            return self.backup_timestamp < other.backup_timestamp
+        except exc.QubesPropertyAccessError:
             return False
-        elif self.backup_timestamp == other.backup_timestamp:
-            return self.vm.name < other.vm.name
-        elif not self.backup_timestamp:
-            return False
-        elif not other.backup_timestamp:
-            return True
-        return self.backup_timestamp < other.backup_timestamp

--- a/qubesmanager/table_widgets.py
+++ b/qubesmanager/table_widgets.py
@@ -579,5 +579,5 @@ class VmLastBackupItem(QtGui.QTableWidgetItem):
             elif not other.backup_timestamp:
                 return True
             return self.backup_timestamp < other.backup_timestamp
-        except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
+        except exc.QubesPropertyAccessError:  # pylint: disable=no-member
             return False

--- a/qubesmanager/table_widgets.py
+++ b/qubesmanager/table_widgets.py
@@ -24,7 +24,7 @@ from PyQt4 import QtGui  # pylint: disable=import-error
 from PyQt4 import QtCore  # pylint: disable=import-error
 # pylint: disable=too-few-public-methods
 
-from qubesadmin import exc  # pylint: disable=no-name-in-module
+from qubesadmin import exc
 
 power_order = QtCore.Qt.DescendingOrder
 update_order = QtCore.Qt.AscendingOrder
@@ -85,7 +85,7 @@ class VmTypeWidget(VmIconWidget):
                 elif self.value == other.value:
                     return self.vm.name < other.vm.name
                 return self.value < other.value
-            except exc.QubesPropertyAccessError:
+            except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
                 return False
 
     def __init__(self, vm, parent=None):
@@ -135,7 +135,7 @@ class VmLabelWidget(VmIconWidget):
                 elif self.value == other.value:
                     return self.vm.name < other.vm.name
                 return self.value < other.value
-            except exc.QubesPropertyAccessError:
+            except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
                 return False
 
     def __init__(self, vm, parent=None):
@@ -166,7 +166,7 @@ class VmNameItem(QtGui.QTableWidgetItem):
             elif other.qid == 0:
                 return False
             return super(VmNameItem, self).__lt__(other)
-        except exc.QubesPropertyAccessError:
+        except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
             return False
 
 
@@ -212,7 +212,7 @@ class VmInfoWidget(QtGui.QWidget):
                     return True
                 elif other.vm.qid == 0:
                     return False
-            except exc.QubesPropertyAccessError:
+            except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
                 return False
 
             self_val = self.upd_info_item.value
@@ -303,7 +303,7 @@ class VmTemplateItem(QtGui.QTableWidgetItem):
             elif self.text() == other.text():
                 return self.vm.name < other.vm.name
             return super(VmTemplateItem, self).__lt__(other)
-        except exc.QubesPropertyAccessError:
+        except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
             return False
 
 
@@ -330,7 +330,7 @@ class VmNetvmItem(QtGui.QTableWidgetItem):
             elif self.text() == other.text():
                 return self.vm.name < other.vm.name
             return super(VmNetvmItem, self).__lt__(other)
-        except exc.QubesPropertyAccessError:
+        except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
             return False
 
 
@@ -354,7 +354,7 @@ class VmInternalItem(QtGui.QTableWidgetItem):
             elif other.vm.qid == 0:
                 return False
             return super(VmInternalItem, self).__lt__(other)
-        except exc.QubesPropertyAccessError:
+        except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
             return False
 
 
@@ -384,7 +384,7 @@ class VmUpdateInfoWidget(QtGui.QWidget):
                 elif self.value == other.value:
                     return self.vm.name < other.vm.name
                 return self.value < other.value
-            except exc.QubesPropertyAccessError:
+            except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
                 return False
 
     def __init__(self, vm, show_text=True, parent=None):
@@ -494,7 +494,7 @@ class VmSizeOnDiskItem(QtGui.QTableWidgetItem):
             elif self.value == other.value:
                 return self.vm.name < other.vm.name
             return self.value < other.value
-        except exc.QubesPropertyAccessError:
+        except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
             return False
 
 
@@ -517,7 +517,7 @@ class VmIPItem(QtGui.QTableWidgetItem):
             elif other.vm.qid == 0:
                 return False
             return super(VmIPItem, self).__lt__(other)
-        except exc.QubesPropertyAccessError:
+        except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
             return False
 
 
@@ -544,7 +544,7 @@ class VmIncludeInBackupsItem(QtGui.QTableWidgetItem):
             elif self.vm.include_in_backups == other.vm.include_in_backups:
                 return self.vm.name < other.vm.name
             return self.vm.include_in_backups < other.vm.include_in_backups
-        except exc.QubesPropertyAccessError:
+        except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
             return False
 
 
@@ -579,5 +579,5 @@ class VmLastBackupItem(QtGui.QTableWidgetItem):
             elif not other.backup_timestamp:
                 return True
             return self.backup_timestamp < other.backup_timestamp
-        except exc.QubesPropertyAccessError:
+        except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
             return False

--- a/qubesmanager/table_widgets.py
+++ b/qubesmanager/table_widgets.py
@@ -85,7 +85,7 @@ class VmTypeWidget(VmIconWidget):
                 elif self.value == other.value:
                     return self.vm.name < other.vm.name
                 return self.value < other.value
-            except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
+            except exc.QubesPropertyAccessError:  # pylint: disable=no-member
                 return False
 
     def __init__(self, vm, parent=None):
@@ -135,7 +135,7 @@ class VmLabelWidget(VmIconWidget):
                 elif self.value == other.value:
                     return self.vm.name < other.vm.name
                 return self.value < other.value
-            except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
+            except exc.QubesPropertyAccessError:  # pylint: disable=no-member
                 return False
 
     def __init__(self, vm, parent=None):
@@ -166,7 +166,7 @@ class VmNameItem(QtGui.QTableWidgetItem):
             elif other.qid == 0:
                 return False
             return super(VmNameItem, self).__lt__(other)
-        except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
+        except exc.QubesPropertyAccessError:  # pylint: disable=no-member
             return False
 
 
@@ -212,7 +212,7 @@ class VmInfoWidget(QtGui.QWidget):
                     return True
                 elif other.vm.qid == 0:
                     return False
-            except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
+            except exc.QubesPropertyAccessError:  # pylint: disable=no-member
                 return False
 
             self_val = self.upd_info_item.value
@@ -303,7 +303,7 @@ class VmTemplateItem(QtGui.QTableWidgetItem):
             elif self.text() == other.text():
                 return self.vm.name < other.vm.name
             return super(VmTemplateItem, self).__lt__(other)
-        except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
+        except exc.QubesPropertyAccessError:  # pylint: disable=no-member
             return False
 
 
@@ -330,7 +330,7 @@ class VmNetvmItem(QtGui.QTableWidgetItem):
             elif self.text() == other.text():
                 return self.vm.name < other.vm.name
             return super(VmNetvmItem, self).__lt__(other)
-        except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
+        except exc.QubesPropertyAccessError:  # pylint: disable=no-member
             return False
 
 
@@ -354,7 +354,7 @@ class VmInternalItem(QtGui.QTableWidgetItem):
             elif other.vm.qid == 0:
                 return False
             return super(VmInternalItem, self).__lt__(other)
-        except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
+        except exc.QubesPropertyAccessError:  # pylint: disable=no-member
             return False
 
 
@@ -384,7 +384,7 @@ class VmUpdateInfoWidget(QtGui.QWidget):
                 elif self.value == other.value:
                     return self.vm.name < other.vm.name
                 return self.value < other.value
-            except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
+            except exc.QubesPropertyAccessError:  # pylint: disable=no-member
                 return False
 
     def __init__(self, vm, show_text=True, parent=None):
@@ -494,7 +494,7 @@ class VmSizeOnDiskItem(QtGui.QTableWidgetItem):
             elif self.value == other.value:
                 return self.vm.name < other.vm.name
             return self.value < other.value
-        except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
+        except exc.QubesPropertyAccessError:  # pylint: disable=no-member
             return False
 
 
@@ -517,7 +517,7 @@ class VmIPItem(QtGui.QTableWidgetItem):
             elif other.vm.qid == 0:
                 return False
             return super(VmIPItem, self).__lt__(other)
-        except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
+        except exc.QubesPropertyAccessError:  # pylint: disable=no-member
             return False
 
 
@@ -544,7 +544,7 @@ class VmIncludeInBackupsItem(QtGui.QTableWidgetItem):
             elif self.vm.include_in_backups == other.vm.include_in_backups:
                 return self.vm.name < other.vm.name
             return self.vm.include_in_backups < other.vm.include_in_backups
-        except exc.QubesPropertyAccessError:  # pylint: disable=no-name-in-module
+        except exc.QubesPropertyAccessError:  # pylint: disable=no-member
             return False
 
 

--- a/qubesmanager/table_widgets.py
+++ b/qubesmanager/table_widgets.py
@@ -75,6 +75,7 @@ class VmTypeWidget(VmIconWidget):
         def set_value(self, value):
             self.value = value
 
+        #pylint: disable=too-many-return-statements
         def __lt__(self, other):
             try:
                 if self.vm.qid == 0:
@@ -124,6 +125,7 @@ class VmLabelWidget(VmIconWidget):
         def set_value(self, value):
             self.value = value
 
+        #pylint: disable=too-many-return-statements
         def __lt__(self, other):
             try:
                 if self.vm.qid == 0:
@@ -156,6 +158,7 @@ class VmNameItem(QtGui.QTableWidgetItem):
         self.setTextAlignment(QtCore.Qt.AlignVCenter)
         self.qid = vm.qid
 
+     #pylint: disable=too-many-return-statements
     def __lt__(self, other):
         try:
             if self.qid == 0:
@@ -562,6 +565,7 @@ class VmLastBackupItem(QtGui.QTableWidgetItem):
         else:
             self.setText("")
 
+    #pylint: disable=too-many-return-statements
     def __lt__(self, other):
         try:
             if self.vm.qid == 0:

--- a/qubesmanager/table_widgets.py
+++ b/qubesmanager/table_widgets.py
@@ -85,7 +85,7 @@ class VmTypeWidget(VmIconWidget):
                 elif self.value == other.value:
                     return self.vm.name < other.vm.name
                 return self.value < other.value
-            except exc.QubesPropertyAccessError(BaseException):
+            except exc.QubesPropertyAccessError:
                 return False
 
     def __init__(self, vm, parent=None):
@@ -135,7 +135,7 @@ class VmLabelWidget(VmIconWidget):
                 elif self.value == other.value:
                     return self.vm.name < other.vm.name
                 return self.value < other.value
-            except exc.QubesPropertyAccessError(BaseException):
+            except exc.QubesPropertyAccessError:
                 return False
 
     def __init__(self, vm, parent=None):
@@ -166,7 +166,7 @@ class VmNameItem(QtGui.QTableWidgetItem):
             elif other.qid == 0:
                 return False
             return super(VmNameItem, self).__lt__(other)
-        except exc.QubesPropertyAccessError(BaseException):
+        except exc.QubesPropertyAccessError:
             return False
 
 
@@ -212,7 +212,7 @@ class VmInfoWidget(QtGui.QWidget):
                     return True
                 elif other.vm.qid == 0:
                     return False
-            except exc.QubesPropertyAccessError(BaseException):
+            except exc.QubesPropertyAccessError:
                 return False
 
             self_val = self.upd_info_item.value
@@ -303,7 +303,7 @@ class VmTemplateItem(QtGui.QTableWidgetItem):
             elif self.text() == other.text():
                 return self.vm.name < other.vm.name
             return super(VmTemplateItem, self).__lt__(other)
-        except exc.QubesPropertyAccessError(BaseException):
+        except exc.QubesPropertyAccessError:
             return False
 
 
@@ -330,7 +330,7 @@ class VmNetvmItem(QtGui.QTableWidgetItem):
             elif self.text() == other.text():
                 return self.vm.name < other.vm.name
             return super(VmNetvmItem, self).__lt__(other)
-        except exc.QubesPropertyAccessError(BaseException):
+        except exc.QubesPropertyAccessError:
             return False
 
 
@@ -354,7 +354,7 @@ class VmInternalItem(QtGui.QTableWidgetItem):
             elif other.vm.qid == 0:
                 return False
             return super(VmInternalItem, self).__lt__(other)
-        except exc.QubesPropertyAccessError(BaseException):
+        except exc.QubesPropertyAccessError:
             return False
 
 
@@ -384,7 +384,7 @@ class VmUpdateInfoWidget(QtGui.QWidget):
                 elif self.value == other.value:
                     return self.vm.name < other.vm.name
                 return self.value < other.value
-            except exc.QubesPropertyAccessError(BaseException):
+            except exc.QubesPropertyAccessError:
                 return False
 
     def __init__(self, vm, show_text=True, parent=None):
@@ -494,7 +494,7 @@ class VmSizeOnDiskItem(QtGui.QTableWidgetItem):
             elif self.value == other.value:
                 return self.vm.name < other.vm.name
             return self.value < other.value
-        except exc.QubesPropertyAccessError(BaseException):
+        except exc.QubesPropertyAccessError:
             return False
 
 
@@ -517,7 +517,7 @@ class VmIPItem(QtGui.QTableWidgetItem):
             elif other.vm.qid == 0:
                 return False
             return super(VmIPItem, self).__lt__(other)
-        except exc.QubesPropertyAccessError(BaseException):
+        except exc.QubesPropertyAccessError:
             return False
 
 
@@ -544,7 +544,7 @@ class VmIncludeInBackupsItem(QtGui.QTableWidgetItem):
             elif self.vm.include_in_backups == other.vm.include_in_backups:
                 return self.vm.name < other.vm.name
             return self.vm.include_in_backups < other.vm.include_in_backups
-        except exc.QubesPropertyAccessError(BaseException):
+        except exc.QubesPropertyAccessError:
             return False
 
 
@@ -579,5 +579,5 @@ class VmLastBackupItem(QtGui.QTableWidgetItem):
             elif not other.backup_timestamp:
                 return True
             return self.backup_timestamp < other.backup_timestamp
-        except exc.QubesPropertyAccessError(BaseException):
+        except exc.QubesPropertyAccessError:
             return False

--- a/qubesmanager/table_widgets.py
+++ b/qubesmanager/table_widgets.py
@@ -24,7 +24,7 @@ from PyQt4 import QtGui  # pylint: disable=import-error
 from PyQt4 import QtCore  # pylint: disable=import-error
 # pylint: disable=too-few-public-methods
 
-from qubesadmin import exc
+from qubesadmin import exc  # pylint: disable=no-name-in-module
 
 power_order = QtCore.Qt.DescendingOrder
 update_order = QtCore.Qt.AscendingOrder

--- a/qubesmanager/table_widgets.py
+++ b/qubesmanager/table_widgets.py
@@ -417,7 +417,7 @@ class VmUpdateInfoWidget(QtGui.QWidget):
                         outdated_state = "outdated"
                         break
 
-        elif self.vm.klass == 'TemplateVM' and \
+        elif self.vm.klass in {'TemplateVM', 'StandaloneVM'} and \
                 self.vm.features.get('updates-available', False):
             outdated_state = 'update'
 

--- a/qubesmanager/table_widgets.py
+++ b/qubesmanager/table_widgets.py
@@ -85,7 +85,7 @@ class VmTypeWidget(VmIconWidget):
                 elif self.value == other.value:
                     return self.vm.name < other.vm.name
                 return self.value < other.value
-            except exc.QubesPropertyAccessError:  # pylint: disable=no-member
+            except exc.QubesPropertyAccessError(BaseException):
                 return False
 
     def __init__(self, vm, parent=None):
@@ -135,7 +135,7 @@ class VmLabelWidget(VmIconWidget):
                 elif self.value == other.value:
                     return self.vm.name < other.vm.name
                 return self.value < other.value
-            except exc.QubesPropertyAccessError:  # pylint: disable=no-member
+            except exc.QubesPropertyAccessError(BaseException):
                 return False
 
     def __init__(self, vm, parent=None):
@@ -166,7 +166,7 @@ class VmNameItem(QtGui.QTableWidgetItem):
             elif other.qid == 0:
                 return False
             return super(VmNameItem, self).__lt__(other)
-        except exc.QubesPropertyAccessError:  # pylint: disable=no-member
+        except exc.QubesPropertyAccessError(BaseException):
             return False
 
 
@@ -212,7 +212,7 @@ class VmInfoWidget(QtGui.QWidget):
                     return True
                 elif other.vm.qid == 0:
                     return False
-            except exc.QubesPropertyAccessError:  # pylint: disable=no-member
+            except exc.QubesPropertyAccessError(BaseException):
                 return False
 
             self_val = self.upd_info_item.value
@@ -303,7 +303,7 @@ class VmTemplateItem(QtGui.QTableWidgetItem):
             elif self.text() == other.text():
                 return self.vm.name < other.vm.name
             return super(VmTemplateItem, self).__lt__(other)
-        except exc.QubesPropertyAccessError:  # pylint: disable=no-member
+        except exc.QubesPropertyAccessError(BaseException):
             return False
 
 
@@ -330,7 +330,7 @@ class VmNetvmItem(QtGui.QTableWidgetItem):
             elif self.text() == other.text():
                 return self.vm.name < other.vm.name
             return super(VmNetvmItem, self).__lt__(other)
-        except exc.QubesPropertyAccessError:  # pylint: disable=no-member
+        except exc.QubesPropertyAccessError(BaseException):
             return False
 
 
@@ -354,7 +354,7 @@ class VmInternalItem(QtGui.QTableWidgetItem):
             elif other.vm.qid == 0:
                 return False
             return super(VmInternalItem, self).__lt__(other)
-        except exc.QubesPropertyAccessError:  # pylint: disable=no-member
+        except exc.QubesPropertyAccessError(BaseException):
             return False
 
 
@@ -384,7 +384,7 @@ class VmUpdateInfoWidget(QtGui.QWidget):
                 elif self.value == other.value:
                     return self.vm.name < other.vm.name
                 return self.value < other.value
-            except exc.QubesPropertyAccessError:  # pylint: disable=no-member
+            except exc.QubesPropertyAccessError(BaseException):
                 return False
 
     def __init__(self, vm, show_text=True, parent=None):
@@ -494,7 +494,7 @@ class VmSizeOnDiskItem(QtGui.QTableWidgetItem):
             elif self.value == other.value:
                 return self.vm.name < other.vm.name
             return self.value < other.value
-        except exc.QubesPropertyAccessError:  # pylint: disable=no-member
+        except exc.QubesPropertyAccessError(BaseException):
             return False
 
 
@@ -517,7 +517,7 @@ class VmIPItem(QtGui.QTableWidgetItem):
             elif other.vm.qid == 0:
                 return False
             return super(VmIPItem, self).__lt__(other)
-        except exc.QubesPropertyAccessError:  # pylint: disable=no-member
+        except exc.QubesPropertyAccessError(BaseException):
             return False
 
 
@@ -544,7 +544,7 @@ class VmIncludeInBackupsItem(QtGui.QTableWidgetItem):
             elif self.vm.include_in_backups == other.vm.include_in_backups:
                 return self.vm.name < other.vm.name
             return self.vm.include_in_backups < other.vm.include_in_backups
-        except exc.QubesPropertyAccessError:  # pylint: disable=no-member
+        except exc.QubesPropertyAccessError(BaseException):
             return False
 
 
@@ -579,5 +579,5 @@ class VmLastBackupItem(QtGui.QTableWidgetItem):
             elif not other.backup_timestamp:
                 return True
             return self.backup_timestamp < other.backup_timestamp
-        except exc.QubesPropertyAccessError:  # pylint: disable=no-member
+        except exc.QubesPropertyAccessError(BaseException):
             return False


### PR DESCRIPTION
I think this way is pretty overloaded. I would prefer catching the exception on main handle_exception(), check if the VM was removed and if yes, ignore it. Maybe I should check if the VM was removed before pass the exception but I am not sure about how to do it. At least I catch only the affected exception but it could mean another errors.

I also fixed two minor things:
- 'StandaloneVM's were not checked for updates. It stills missing checking for dom0 updates, how are them notified?
- the settings window was closed on renaming regardless the name is already in use.