### PR TITLE
Log dialog separate

### DIFF
--- a/qubesmanager/log_dialog.py
+++ b/qubesmanager/log_dialog.py
@@ -58,7 +58,7 @@ class LogDialog(ui_logdlg.Ui_LogDialog, QtGui.QDialog):
         if log.tell() > LOG_DISPLAY_SIZE:
             self.displayed_text = self.tr(
                 "(Showing only last %d bytes of file)\n") % LOG_DISPLAY_SIZE
-            log.seek(-LOG_DISPLAY_SIZE, os.SEEK_END)
+            log.seek(log.tell()-LOG_DISPLAY_SIZE, os.SEEK_SET)
         else:
             log.seek(0, os.SEEK_SET)
         self.displayed_text += log.read()

--- a/qubesmanager/log_dialog.py
+++ b/qubesmanager/log_dialog.py
@@ -19,13 +19,15 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 #
-
+import sys
 from PyQt4 import QtCore  # pylint: disable=import-error
 from PyQt4 import QtGui  # pylint: disable=import-error
 
 from . import ui_logdlg   # pylint: disable=no-name-in-module
 from . import clipboard
 import os
+
+from qubesadmin import Qubes
 
 # Display only this size of log
 LOG_DISPLAY_SIZE = 1024*1024
@@ -65,3 +67,18 @@ class LogDialog(ui_logdlg.Ui_LogDialog, QtGui.QDialog):
 
     def copy_to_clipboard_triggered(self):
         clipboard.copy_text_to_qubes_clipboard(self.displayed_text)
+
+
+def main():
+    qubes_app = Qubes()
+    qt_app = QtGui.QApplication(sys.argv)
+
+    log_window = LogDialog(qubes_app, sys.argv[1])
+    log_window.show()
+
+    qt_app.exec_()
+    qt_app.exit()
+
+
+if __name__ == "__main__":
+    main()

--- a/rpm_spec/qmgr.spec.in
+++ b/rpm_spec/qmgr.spec.in
@@ -66,6 +66,7 @@ rm -rf $RPM_BUILD_ROOT
 /usr/bin/qubes-backup
 /usr/bin/qubes-backup-restore
 /usr/bin/qubes-qube-manager
+/usr/bin/qubes-log-viewer
 /usr/libexec/qubes-manager/mount_for_backup.sh
 /usr/libexec/qubes-manager/qvm_about.sh
 

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ if __name__ == '__main__':
                 'qubes-vm-boot-from-device = qubesmanager.bootfromdevice:main',
                 'qubes-backup = qubesmanager.backup:main',
                 'qubes-backup-restore = qubesmanager.restore:main',
-                'qubes-qube-manager = qubesmanager.qube_manager:main'
+                'qubes-qube-manager = qubesmanager.qube_manager:main',
+                'qubes-log-viewer = qubesmanager.log_dialog:main'
             ],
         })


### PR DESCRIPTION
 Log dialog viewer is now also available as a separate tool (introduced
to simplify displaying logs in the qui-domains tool)
Added entry point and main() to enable using log viewer as a separate tool.
Includes a minor fix for error that occurred with large log files due to changes
in Python 3.