### PR TITLE
Qubes Manager: Rename "Disk size" to "Disk usage"

### DIFF
--- a/ui/qubemanager.ui
+++ b/ui/qubemanager.ui
@@ -211,7 +211,7 @@
       </column>
       <column>
        <property name="text">
-        <string>Disk size</string>
+        <string>Disk usage</string>
        </property>
       </column>
       <column>


### PR DESCRIPTION
What's shown in that column is the disk space that used rather than the size of the full disk. So, let's be clear about that.