### PR TITLE
Modified Qube Manager menu for dom0

### DIFF
--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -339,6 +339,14 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
         self.tools_context_menu.addAction(self.action_toolbar)
         self.tools_context_menu.addAction(self.action_menubar)
 
+        self.dom0_context_menu = QtGui.QMenu(self)
+        self.dom0_context_menu.addAction(self.action_global_settings)
+        self.dom0_context_menu.addAction(self.action_updatevm)
+        self.dom0_context_menu.addSeparator()
+
+        self.dom0_context_menu.addMenu(self.logs_menu)
+        self.dom0_context_menu.addSeparator()
+
         self.connect(
             self.table.horizontalHeader(),
             QtCore.SIGNAL("sortIndicatorChanged(int, Qt::SortOrder)"),
@@ -1245,7 +1253,10 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
                     menu_empty = False
 
             self.logs_menu.setEnabled(not menu_empty)
-            self.context_menu.exec_(self.table.mapToGlobal(point))
+            if vm.qid == 0:
+                self.dom0_context_menu.exec_(self.table.mapToGlobal(point))
+            else:
+                self.context_menu.exec_(self.table.mapToGlobal(point))
         except exc.QubesPropertyAccessError:
             pass
 


### PR DESCRIPTION
Instead of generic menu with almost everything grayed-out, now
context menu for dom0 has only Global Settings, Logs and update.

references QubesOS/qubes-issues#1382
fixes QubesOS/qubes-issues#1165