### PR TITLE
Removed 'close window' button in progress dialogs in Qube Manager

### DIFF
--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -524,6 +524,9 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
             self.tr(
                 "Loading Qube Manager..."), "", 0, 0)
         progress.setWindowTitle(self.tr("Qube Manager"))
+        progress.setWindowFlags(QtCore.Qt.Window |
+                                QtCore.Qt.WindowTitleHint |
+                                QtCore.Qt.CustomizeWindowHint)
         progress.setCancelButton(None)
         progress.setModal(True)
         progress.show()
@@ -711,6 +714,9 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
             progress = QtGui.QProgressDialog(
                 self.tr(
                     "Removing Qube: <b>{0}</b>...").format(vm.name), "", 0, 0)
+            progress.setWindowFlags(QtCore.Qt.Window |
+                                    QtCore.Qt.WindowTitleHint |
+                                    QtCore.Qt.CustomizeWindowHint)
             progress.setCancelButton(None)
             progress.setModal(True)
             progress.show()
@@ -765,6 +771,9 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
         progress = QtGui.QProgressDialog(
             self.tr("Cloning Qube <b>{0}</b> to <b>{1}</b>...").format(
                 vm.name, clone_name), "", 0, 0)
+        progress.setWindowFlags(QtCore.Qt.Window |
+                                QtCore.Qt.WindowTitleHint |
+                                QtCore.Qt.CustomizeWindowHint)
         progress.setCancelButton(None)
         progress.setModal(True)
         progress.show()
@@ -1008,6 +1017,9 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
                 self.tr(
                     "<b>{0}</b><br>Please wait for the updater to "
                     "launch...").format(vm.name), "", 0, 0)
+        progress.setWindowFlags(QtCore.Qt.Window |
+                                QtCore.Qt.WindowTitleHint |
+                                QtCore.Qt.CustomizeWindowHint)
         progress.setCancelButton(None)
         progress.setModal(True)
         progress.show()


### PR DESCRIPTION
The ability to close window suggested to the user (falsely) that
they can close the window and thus abort the operation (like deleting
a VM). To avoid confusion, the button has been exorcised.

fixes QubesOS/qubes-issues#1479