### PR TITLE
Tiny fix for rare error in Qubes Manager

### DIFF
--- a/qubesmanager/main.py
+++ b/qubesmanager/main.py
@@ -2063,7 +2063,7 @@ def show_manager():
 
 def bring_manager_to_front():
     if manager_window.isVisible():
-        subprocess.check_call(
+        subprocess.call(
             ['/usr/bin/wmctrl', '-R', str(manager_window.windowTitle())])
 
     else:


### PR DESCRIPTION
It's not necessary to use check_call, especially as raising Qubes
Manager can cause errors shortly after system start.

fixes QubesOS/qubes-issues#1604