### PR TITLE
Sort performance boost

### DIFF
--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -139,15 +139,21 @@ class VmRowInTable(object):
         widget will extract the data from VM object
         :return: None
         """
-        self.info_widget.update_vm_state()
-        self.template_widget.update()
-        self.netvm_widget.update()
-        self.internal_widget.update()
-        self.ip_widget.update()
-        self.include_in_backups_widget.update()
-        self.last_backup_widget.update()
-        if update_size_on_disk:
-            self.size_widget.update()
+        try:
+            self.info_widget.update_vm_state()
+            self.template_widget.update()
+            self.netvm_widget.update()
+            self.internal_widget.update()
+            self.ip_widget.update()
+            self.include_in_backups_widget.update()
+            self.last_backup_widget.update()
+            if update_size_on_disk:
+                self.size_widget.update()
+        except exc.QubesPropertyAccessError:
+            pass
+
+        #force re-sorting
+        self.table.setSortingEnabled(True)
 
 
 vm_shutdown_timeout = 20000  # in msec

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -313,9 +313,6 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
             QtGui.QHeaderView.Interactive)
         self.table.horizontalHeader().setStretchLastSection(True)
 
-        self.table.sortItems(self.columns_indices[self.sort_by_column],
-                             self.sort_order)
-
         self.context_menu = QtGui.QMenu(self)
 
         self.context_menu.addAction(self.action_settings)

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -546,8 +546,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
             vm_row = VmRowInTable(vm, row_no, self.table)
             vms_in_table[vm.qid] = vm_row
             row_no += 1
-            if row_no % 5 == 0:
-                self.qt_app.processEvents()
+            self.qt_app.processEvents()
 
         self.vms_list = vms_list
         self.vms_in_table = vms_in_table

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -969,12 +969,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
             settings_window = settings.VMSettingsWindow(
                 vm, self.qt_app, "basic")
             settings_window.exec_()
-
-            # vm could be deleted on renaming
-            try:
-                self.vms_in_table[vm.qid].update()
-            except exc.QubesPropertyAccessError:
-                pass
+            self.vms_in_table[vm.qid].update()
 
 
     # noinspection PyArgumentList

--- a/qubesmanager/table_widgets.py
+++ b/qubesmanager/table_widgets.py
@@ -523,7 +523,7 @@ class VmIncludeInBackupsItem(QtGui.QTableWidgetItem):
             self.include_in_backups = False
 
     def __lt__(self, other):
-        if self.vm.qid == 0:
+        if self.qid == 0:
             return True
         elif other.qid == 0:
             return False

--- a/qubesmanager/table_widgets.py
+++ b/qubesmanager/table_widgets.py
@@ -157,8 +157,7 @@ class VmNameItem(QtGui.QTableWidgetItem):
             return True
         elif other.qid == 0:
             return False
-        else:
-            return super(VmNameItem, self).__lt__(other)
+        return super(VmNameItem, self).__lt__(other)
 
 
 class VmStatusIcon(QtGui.QLabel):
@@ -197,7 +196,7 @@ class VmInfoWidget(QtGui.QWidget):
     class VmInfoItem(QtGui.QTableWidgetItem):
         def __init__(self, on_icon, upd_info_item, vm):
             super(VmInfoWidget.VmInfoItem, self).__init__()
-            self.on_icon = on_icon 
+            self.on_icon = on_icon
             self.upd_info_item = upd_info_item
             self.vm = vm
             self.qid = vm.qid
@@ -259,7 +258,8 @@ class VmInfoWidget(QtGui.QWidget):
         self.blk_icon.setVisible(False)
         self.error_icon.setVisible(False)
 
-        self.table_item = self.VmInfoItem(self.on_icon, self.upd_info.table_item, vm)
+        self.table_item = self.VmInfoItem(self.on_icon,\
+                self.upd_info.table_item, vm)
 
     def update_vm_state(self):
         self.on_icon.update()
@@ -314,13 +314,13 @@ class VmNetvmItem(QtGui.QTableWidgetItem):
             self.setText(self.vm.netvm.name)
 
     def __lt__(self, other):
-            if self.qid == 0:
-                return True
-            elif other.qid == 0:
-                return False
-            elif self.text() == other.text():
-                return self.name < other.name
-            return super(VmNetvmItem, self).__lt__(other)
+        if self.qid == 0:
+            return True
+        elif other.qid == 0:
+            return False
+        elif self.text() == other.text():
+            return self.name < other.name
+        return super(VmNetvmItem, self).__lt__(other)
 
 
 class VmInternalItem(QtGui.QTableWidgetItem):


### PR DESCRIPTION
Hi,

I cached all the variables used in _lt_ funcs so they don't need to access vm object. This way all columns sort as fast as the 'name' column in previous version.

As a side effect, _lt_ functions don't need try/except anymore and I moved all them to just one on VmRowInTable.update(), it looks better and probably fix some unknown similar problem.