### PR TITLE
Remove templates from listing in UpdateVM and ClockVm in Global Settings

### DIFF
--- a/qubesmanager/global_settings.py
+++ b/qubesmanager/global_settings.py
@@ -63,13 +63,15 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
         # set up updatevm choice
         self.update_vm_vmlist, self.update_vm_idx = utils.prepare_vm_choice(
             self.update_vm_combo, self.qvm_collection, 'updatevm',
-            None, allow_none=True
+            None, allow_none=True,
+            filter_function=(lambda vm: vm.klass != 'TemplateVM')
         )
 
         # set up clockvm choice
         self.clock_vm_vmlist, self.clock_vm_idx = utils.prepare_vm_choice(
             self.clock_vm_combo, self.qvm_collection, 'clockvm',
-            None, allow_none=True
+            None, allow_none=True,
+            filter_function=(lambda vm: vm.klass != 'TemplateVM')
         )
 
         # set up default netvm


### PR DESCRIPTION
A user should not be able to set a TemplateVM as an UpdateVM or ClockVM
in Global Settings.

fixes QubesOS/qubes-issues#1831