### PR TITLE
Offset context menu in Manager to avoid accidental clicks (R4.0)

### DIFF
--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -1254,9 +1254,11 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
 
             self.logs_menu.setEnabled(not menu_empty)
             if vm.qid == 0:
-                self.dom0_context_menu.exec_(self.table.mapToGlobal(point))
+                self.dom0_context_menu.exec_(self.table.mapToGlobal(
+                    point + QtCore.QPoint(10, 0)))
             else:
-                self.context_menu.exec_(self.table.mapToGlobal(point))
+                self.context_menu.exec_(self.table.mapToGlobal(
+                    point + QtCore.QPoint(10, 0)))
         except exc.QubesPropertyAccessError:
             pass
 

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -339,6 +339,14 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
         self.tools_context_menu.addAction(self.action_toolbar)
         self.tools_context_menu.addAction(self.action_menubar)
 
+        self.dom0_context_menu = QtGui.QMenu(self)
+        self.dom0_context_menu.addAction(self.action_global_settings)
+        self.dom0_context_menu.addAction(self.action_updatevm)
+        self.dom0_context_menu.addSeparator()
+
+        self.dom0_context_menu.addMenu(self.logs_menu)
+        self.dom0_context_menu.addSeparator()
+
         self.connect(
             self.table.horizontalHeader(),
             QtCore.SIGNAL("sortIndicatorChanged(int, Qt::SortOrder)"),
@@ -1245,7 +1253,10 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
                     menu_empty = False
 
             self.logs_menu.setEnabled(not menu_empty)
-            self.context_menu.exec_(self.table.mapToGlobal(point))
+            if vm.qid == 0:
+                self.dom0_context_menu.exec_(self.table.mapToGlobal(point))
+            else:
+                self.context_menu.exec_(self.table.mapToGlobal(point))
         except exc.QubesPropertyAccessError:
             pass
 


### PR DESCRIPTION
Small fix to Qubes Manager to open the context menu slightly to the
right of the mouse to avoid accidental clicks. Originally created by
@unman , ported to 4.0 and including changes to context menu from
pull request#100.
Depends on https://github.com/QubesOS/qubes-manager/pull/100 .

fixes QubesOS/qubes-issues#1911
