### PR TITLE
Offset context menu in Manager to avoid accidental clicks (R3.2)

### DIFF
--- a/qubesmanager/main.py
+++ b/qubesmanager/main.py
@@ -1701,7 +1701,7 @@ class VmManagerWindow(Ui_VmManagerWindow, QMainWindow):
         return menu
 
     def open_tools_context_menu(self, widget, point):
-        self.tools_context_menu.exec_(widget.mapToGlobal(point))
+        self.tools_context_menu.exec_(widget.mapToGlobal(point + QPoint(10,0)))
 
     @pyqtSlot('const QPoint&')
     def open_context_menu(self, point):


### PR DESCRIPTION
Small fix to Qubes Manager to open the context menu slightly to the
right of the mouse to avoid accidental clicks. Originally created by
@unman , ported to 3.2 branch.

references QubesOS/qubes-issues#1911
closes https://github.com/QubesOS/qubes-manager/pull/31