### PR TITLE
Fixed bug with starting a running VM in Qubes Manager

### DIFF
--- a/qubesmanager/main.py
+++ b/qubesmanager/main.py
@@ -1210,7 +1210,8 @@ class VmManagerWindow(Ui_VmManagerWindow, QMainWindow):
 	self.start_vm(vm)
 
     def start_vm(self, vm):
-        assert not vm.is_running()
+        if vm.is_running():
+            return
         thread_monitor = ThreadMonitor()
         thread = threading.Thread(target=self.do_start_vm,
                                   args=(vm, thread_monitor))


### PR DESCRIPTION
On some occasions (e.g., when restarting) Qubes Manager would try to
start a VM twice, and threw an error. Removed the assertion and instead
just happily accept that there's nothing to do when starting a running
VM.

fixes QubesOS/qubes-issues#2362