### PR TITLE
Fixed VM name validation in GUI tools (Create VM, Settings, Manager) (R4)

### DIFF
--- a/qubesmanager/create_new_vm.py
+++ b/qubesmanager/create_new_vm.py
@@ -71,7 +71,7 @@ class NewVmDlg(QtGui.QDialog, Ui_NewVMDlg):
             allow_internal=False, allow_default=True, allow_none=True)
 
         self.name.setValidator(QtGui.QRegExpValidator(
-            QtCore.QRegExp("[a-zA-Z0-9-]*", QtCore.Qt.CaseInsensitive), None))
+            QtCore.QRegExp("[a-zA-Z0-9_-]*", QtCore.Qt.CaseInsensitive), None))
         self.name.selectAll()
         self.name.setFocus()
 

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -263,7 +263,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
 
         self.searchbox = SearchBox()
         self.searchbox.setValidator(QtGui.QRegExpValidator(
-            QtCore.QRegExp("[a-zA-Z0-9-]*", QtCore.Qt.CaseInsensitive), None))
+            QtCore.QRegExp("[a-zA-Z0-9_-]*", QtCore.Qt.CaseInsensitive), None))
         self.searchContainer.addWidget(self.searchbox)
 
         self.connect(self.table, QtCore.SIGNAL("itemSelectionChanged()"),

--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -294,7 +294,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
         self.vmname.setText(self.vm.name)
         self.vmname.setValidator(
             QtGui.QRegExpValidator(
-                QtCore.QRegExp("[a-zA-Z0-9-]*",
+                QtCore.QRegExp("[a-zA-Z0-9_-]*",
                                QtCore.Qt.CaseInsensitive), None))
         self.vmname.setEnabled(False)
         self.rename_vm_button.setEnabled(not self.vm.is_running())


### PR DESCRIPTION
VM name validation in various places in Manager did not allow a
perfectly legal '_' character.

references QubesOS/qubes-issues#2422