### PR TITLE
Fixed VM name validation in GUI tools (Create VM, Settings, Manager) (R3.2)

### DIFF
--- a/qubesmanager/create_new_vm.py
+++ b/qubesmanager/create_new_vm.py
@@ -74,7 +74,8 @@ class NewVmDlg (QDialog, Ui_NewVMDlg):
         self.fill_template_list()
         self.fill_netvm_list()
 
-        self.vmname.setValidator(QRegExpValidator(QRegExp("[a-zA-Z0-9_-.]*", Qt.CaseInsensitive), None))
+        self.vmname.setValidator(QRegExpValidator(
+            QRegExp("[a-zA-Z0-9_.-]*", Qt.CaseInsensitive), None))
         self.vmname.selectAll()
         self.vmname.setFocus()
 

--- a/qubesmanager/create_new_vm.py
+++ b/qubesmanager/create_new_vm.py
@@ -57,7 +57,7 @@ class NewVmDlg (QDialog, Ui_NewVMDlg):
             from qubes.qubes import QubesHVm
         except ImportError:
             pass
-        else: 
+        else:
             self.hvm_radio.setEnabled(True)
             self.hvmtpl_radio.setEnabled(True)
 
@@ -74,7 +74,7 @@ class NewVmDlg (QDialog, Ui_NewVMDlg):
         self.fill_template_list()
         self.fill_netvm_list()
 
-        self.vmname.setValidator(QRegExpValidator(QRegExp("[a-zA-Z0-9-]*", Qt.CaseInsensitive), None))
+        self.vmname.setValidator(QRegExpValidator(QRegExp("[a-zA-Z0-9_-.]*", Qt.CaseInsensitive), None))
         self.vmname.selectAll()
         self.vmname.setFocus()
 
@@ -132,7 +132,7 @@ class NewVmDlg (QDialog, Ui_NewVMDlg):
         if checked:
             self.fill_netvm_list()
             self.netvm_name.setEnabled(True)
-        else:    
+        else:
             self.netvm_name.clear()
             self.netvm_name.setEnabled(False)
 
@@ -194,7 +194,7 @@ class NewVmDlg (QDialog, Ui_NewVMDlg):
             return
 
         label = self.label_list[self.vmlabel.currentIndex()]
-        
+
         template_vm = None
         if self.template_name.isEnabled():
             if len(self.template_vm_list) == 0:

--- a/qubesmanager/main.py
+++ b/qubesmanager/main.py
@@ -368,7 +368,7 @@ class VmManagerWindow(Ui_VmManagerWindow, QMainWindow):
         self.blk_watch_thread.start()
 
         self.searchbox = SearchBox()
-        self.searchbox.setValidator(QRegExpValidator(QRegExp("[a-zA-Z0-9_-.]*", Qt.CaseInsensitive), None))
+        self.searchbox.setValidator(QRegExpValidator(QRegExp("[a-zA-Z0-9_.-]*", Qt.CaseInsensitive), None))
         self.searchContainer.addWidget(self.searchbox)
 
         self.connect(self.table, SIGNAL("itemSelectionChanged()"),

--- a/qubesmanager/main.py
+++ b/qubesmanager/main.py
@@ -368,7 +368,7 @@ class VmManagerWindow(Ui_VmManagerWindow, QMainWindow):
         self.blk_watch_thread.start()
 
         self.searchbox = SearchBox()
-        self.searchbox.setValidator(QRegExpValidator(QRegExp("[a-zA-Z0-9-]*", Qt.CaseInsensitive), None))
+        self.searchbox.setValidator(QRegExpValidator(QRegExp("[a-zA-Z0-9_-.]*", Qt.CaseInsensitive), None))
         self.searchContainer.addWidget(self.searchbox)
 
         self.connect(self.table, SIGNAL("itemSelectionChanged()"),

--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -206,7 +206,7 @@ class VMSettingsWindow(Ui_SettingsDialog, QDialog):
 
     def __init_basic_tab__(self):
         self.vmname.setText(self.vm.name)
-        self.vmname.setValidator(QRegExpValidator(QRegExp("[a-zA-Z0-9_-.]*", Qt.CaseInsensitive), None))
+        self.vmname.setValidator(QRegExpValidator(QRegExp("[a-zA-Z0-9_.-]*", Qt.CaseInsensitive), None))
         self.vmname.setEnabled(not self.vm.is_running())
 
         #self.qvm_collection.lock_db_for_reading()

--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -206,7 +206,7 @@ class VMSettingsWindow(Ui_SettingsDialog, QDialog):
 
     def __init_basic_tab__(self):
         self.vmname.setText(self.vm.name)
-        self.vmname.setValidator(QRegExpValidator(QRegExp("[a-zA-Z0-9-]*", Qt.CaseInsensitive), None))
+        self.vmname.setValidator(QRegExpValidator(QRegExp("[a-zA-Z0-9_-.]*", Qt.CaseInsensitive), None))
         self.vmname.setEnabled(not self.vm.is_running())
 
         #self.qvm_collection.lock_db_for_reading()


### PR DESCRIPTION
VM name validation in various places in Manager did not allow
perfectly legal otherwise '_' and '.' characters.

references QubesOS/qubes-issues#2422
fixes QubesOS/qubes-issues#3301