### PR TITLE
Disable block device attach menu in Qubes Manager for dom0

### DIFF
--- a/qubesmanager/main.py
+++ b/qubesmanager/main.py
@@ -1732,7 +1732,7 @@ class VmManagerWindow(Ui_VmManagerWindow, QMainWindow):
         self.logs_menu.setEnabled(not menu_empty)
 
         # blk menu
-        if not running:
+        if not running or vm.qid == 0:
             self.blk_menu.setEnabled(False)
         else:
             self.blk_menu.clear()


### PR DESCRIPTION
Using "attach block device" to dom0 was causing total failure of
Qubes Manager. The menu is now disabled for dom0.

fixes QubesOS/qubes-issues#2733