### PR TITLE
Make 'NetVm' column in Qube Manager clearer with regars to defaults

### DIFF
--- a/qubesmanager/table_widgets.py
+++ b/qubesmanager/table_widgets.py
@@ -311,7 +311,11 @@ class VmNetvmItem(QtGui.QTableWidgetItem):
         if getattr(self.vm, 'netvm', None) is None:
             self.setText("n/a")
         else:
-            self.setText(self.vm.netvm.name)
+            if self.vm.property_is_default('netvm'):
+                text = 'default (' + self.vm.netvm.name +')'
+            else:
+                text = self.vm.netvm.name
+            self.setText(text)
 
     def __lt__(self, other):
         if self.qid == 0:


### PR DESCRIPTION
When a VM has netvm set to 'default', now Qube Manager will display
'(default)' in front of the netvm's name.

references QubesOS/qubes-issues#3567