### PR TITLE
Fixed incorrect kernel display in VM settings

### DIFF
--- a/qubesmanager/utils.py
+++ b/qubesmanager/utils.py
@@ -60,6 +60,8 @@ def prepare_choice(widget, holder, propname, choice, default,
             oldvalue = qubesadmin.DEFAULT
         else:
             oldvalue = getattr(holder, propname)
+            if oldvalue == '':
+                oldvalue = None
             if transform is not None and oldvalue is not None:
                 oldvalue = transform(oldvalue)
     else:


### PR DESCRIPTION
Kernel set to 'None' was incorrectly displayed as 'default'.

fixes QubesOS/qubes-issues#4043