### PR TITLE
Handling VM dependencies in GUI tools

### DIFF
--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -704,7 +704,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
                 self.tr("This qube cannot be removed. It is used as:"
                         " <br> {} <small>If you want to  remove this qube, "
                         "you should remove or change settings of each qube "
-                        "or setting that uses it.</small>".format(list_text)))
+                        "or setting that uses it.</small>").format(list_text))
             info_dialog.setModal(False)
             info_dialog.show()
             self.qt_app.processEvents()

--- a/qubesmanager/restore.py
+++ b/qubesmanager/restore.py
@@ -134,6 +134,7 @@ class RestoreVMsWindow(ui_restoredlg.Ui_Restore, QtGui.QWizard):
             if self.verify_only.isChecked():
                 self.backup_restore.options.verify_only = True
 
+            # pylint: disable=assignment-from-no-return
             self.vms_to_restore = self.backup_restore.get_restore_info()
 
             for vmname in self.vms_to_restore:
@@ -182,7 +183,7 @@ class RestoreVMsWindow(ui_restoredlg.Ui_Restore, QtGui.QWizard):
             self.__fill_vms_list__()
 
         elif self.currentPage() is self.confirm_page:
-
+            # pylint: disable=assignment-from-no-return
             self.vms_to_restore = self.backup_restore.get_restore_info()
 
             for i in range(self.select_vms_widget.available_list.count()):

--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -495,7 +495,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
                     else:
                         setattr(holder, prop, new_vm)
                 except qubesadmin.exc.QubesException as qex:
-                    failed_props += (holder, prop)
+                    failed_props += [(holder, prop)]
 
             if not failed_props:
                 del self.vm.app.domains[self.vm.name]
@@ -509,8 +509,8 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
                             "name. The system has now both {} and {} qubes. "
                             "To resolve this, please check and change the "
                             "following properties and remove the qube {} "
-                            "manually.<br> ".format(
-                                self.vm.name, name, self.vm.name) + list_text))
+                            "manually.<br> ").format(
+                                self.vm.name, name, self.vm.name) + list_text)
 
         except qubesadmin.exc.QubesException as qex:
             t_monitor.set_error_msg(str(qex))
@@ -534,8 +534,8 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
                 self.tr(
                     "The following qubes using this qube as a template are "
                     "running: <br> {}. <br> In order to rename this qube, you "
-                    "must first shut them down.".format(
-                        ", ".join(running_dependencies))))
+                    "must first shut them down.").format(
+                        ", ".join(running_dependencies)))
             return
 
         new_vm_name, ok = QtGui.QInputDialog.getText(
@@ -570,7 +570,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
                 self.tr("This qube cannot be removed. It is used as:"
                         " <br> {} <small>If you want to  remove this qube, "
                         "you should remove or change settings of each qube "
-                        "or setting that uses it.</small>".format(list_text)))
+                        "or setting that uses it.</small>").format(list_text))
 
             return
 

--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -34,6 +34,7 @@ import traceback
 import sys
 from qubesadmin.tools import QubesArgumentParser
 from qubesadmin import devices
+from qubesadmin import utils as admin_utils
 import qubesadmin.exc
 
 from . import utils
@@ -481,10 +482,35 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
             return False
         return True
 
-    def _rename_vm(self, t_monitor, name):
+    def _rename_vm(self, t_monitor, name, dependencies):
         try:
-            self.vm.app.clone_vm(self.vm, name)
-            del self.vm.app.domains[self.vm.name]
+            new_vm = self.vm.app.clone_vm(self.vm, name)
+
+            failed_props = []
+
+            for (holder, prop) in dependencies:
+                try:
+                    if holder is None:
+                        setattr(self.vm.app, prop, new_vm)
+                    else:
+                        setattr(holder, prop, new_vm)
+                except qubesadmin.exc.QubesException as qex:
+                    failed_props += (holder, prop)
+
+            if not failed_props:
+                del self.vm.app.domains[self.vm.name]
+            else:
+                list_text = utils.format_dependencies_list(failed_props)
+
+                QtGui.QMessageBox.warning(
+                    self,
+                    self.tr("Warning: rename partially unsuccessful"),
+                    self.tr("Some properties could not be changed to the new "
+                            "name. The system has now both {} and {} qubes. "
+                            "To resolve this, please check and change the "
+                            "following properties and remove the qube {} "
+                            "manually.<br> ".format(
+                                self.vm.name, name, self.vm.name) + list_text))
 
         except qubesadmin.exc.QubesException as qex:
             t_monitor.set_error_msg(str(qex))
@@ -494,13 +520,31 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
         t_monitor.set_finished()
 
     def rename_vm(self):
+
+        dependencies = admin_utils.vm_dependencies(self.vm.app, self.vm)
+
+        running_dependencies = [vm.name for (vm, prop) in dependencies
+                                if vm and prop == 'template'
+                                and vm.is_running()]
+
+        if running_dependencies:
+            QtGui.QMessageBox.warning(
+                self,
+                self.tr("Qube cannot be renamed!"),
+                self.tr(
+                    "The following qubes using this qube as a template are "
+                    "running: <br> {}. <br> In order to rename this qube, you "
+                    "must first shut them down.".format(
+                        ", ".join(running_dependencies))))
+            return
+
         new_vm_name, ok = QtGui.QInputDialog.getText(
             self,
             self.tr('Rename qube'),
             self.tr('New name: (WARNING: all other changes will be discarded)'))
 
         if ok:
-            if self._run_in_thread(self._rename_vm, new_vm_name):
+            if self._run_in_thread(self._rename_vm, new_vm_name, dependencies):
                 self.done(0)
 
     def _remove_vm(self, t_monitor):
@@ -515,6 +559,21 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
         t_monitor.set_finished()
 
     def remove_vm(self):
+
+        dependencies = admin_utils.vm_dependencies(self.vm.app, self.vm)
+
+        if dependencies:
+            list_text = utils.format_dependencies_list(dependencies)
+            QtGui.QMessageBox.warning(
+                self,
+                self.tr("Qube cannot be removed!"),
+                self.tr("This qube cannot be removed. It is used as:"
+                        " <br> {} <small>If you want to  remove this qube, "
+                        "you should remove or change settings of each qube "
+                        "or setting that uses it.</small>".format(list_text)))
+
+            return
+
 
         answer, ok = QtGui.QInputDialog.getText(
             self,

--- a/qubesmanager/utils.py
+++ b/qubesmanager/utils.py
@@ -172,3 +172,18 @@ def get_path_from_vm(vm, service_name):
         assert '\0' not in untrusted_path
         return untrusted_path.strip()
     raise ValueError('Unexpected characters in path.')
+
+
+def format_dependencies_list(dependencies):
+    """Given a list of tuples representing properties, formats them in
+    a readable list."""
+
+    list_text = ""
+    for (holder, prop) in dependencies:
+        if holder is None:
+            list_text += "- Global property <b>{}</b> <br>".format(prop)
+        else:
+            list_text += "- <b>{}</b> for qube <b>{}</b> <br>".format(
+                prop, holder.name)
+
+    return list_text

--- a/test-packages/qubesadmin/utils.py
+++ b/test-packages/qubesadmin/utils.py
@@ -8,3 +8,6 @@ def updates_vms_status(*args, **kwargs):
 
 def size_to_human(*args, **kwargs):
     return args[0]
+
+def vm_dependencies(*args):
+    return args[0]


### PR DESCRIPTION
Added the following reactions to VM dependencies in GUI tools:
- Qube Manager will inform the user why they cannot delete a VM (which
properties of which VMs [or global] are using the VM)
- Settings window will try to intelligently rename VMs (change
properties to the new name, if possible, and inform the user what went
wrong if not)
- Settings window will inform the user why they cannot delete a VM
Also, renaming VM from Settings launched from Qube Manager will
refresh the VM list through a horrible hack, to be replaced by a neater
Admin API solution in some near future.

depends on QubesOS/qubes-core-admin-client@ca848ca

fixes QubesOS/qubes-issues#3992
fixes QubesOS/qubes-issues#3993
fixes QubesOS/qubes-issues#3892
fixes QubesOS/qubes-issues#3499