### PR TITLE
Fixed kernelopts in VM settings

### DIFF
--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -648,6 +648,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
                 None,
                 allow_default=True, allow_none=True)
             self.kernel.currentIndexChanged.connect(self.kernel_changed)
+            self.kernel_opts.setText(getattr(self.vm, 'kernelopts', '[]'))
         else:
             self.kernel_groupbox.setVisible(False)
 

--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -648,7 +648,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
                 None,
                 allow_default=True, allow_none=True)
             self.kernel.currentIndexChanged.connect(self.kernel_changed)
-            self.kernel_opts.setText(getattr(self.vm, 'kernelopts', '[]'))
+            self.kernel_opts.setText(getattr(self.vm, 'kernelopts', '-'))
         else:
             self.kernel_groupbox.setVisible(False)
 

--- a/ui/settingsdlg.ui
+++ b/ui/settingsdlg.ui
@@ -483,6 +483,7 @@ border-width: 1px;</string>
                 <property name="font">
                  <font>
                   <weight>50</weight>
+                  <italic>true</italic>
                   <bold>false</bold>
                  </font>
                 </property>


### PR DESCRIPTION
For some reason, they were not being displayed at all. Now fixed.

fixes QubesOS/qubes-issues#4188