### PR TITLE
Fixed error in qube manager of change of global settings

### DIFF
--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -476,6 +476,8 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtGui.QMainWindow):
                     row.info_widget.update_vm_state()
 
     def on_domain_changed(self, vm, _event, **_kwargs):
+        if not vm:  # change of global properties occured
+            return
         try:
             self.vms_in_table[vm.qid].update()
         except exc.QubesPropertyAccessError:


### PR DESCRIPTION
Changing global properties fired an event that crashed qube
manager.

fixes QubesOS/qubes-issues#4385