### PR TITLE
Changed to not force default netvm in Create New VM

### DIFF
--- a/qubesmanager/create_new_vm.py
+++ b/qubesmanager/create_new_vm.py
@@ -154,7 +154,8 @@ class NewVmDlg(QtGui.QDialog, Ui_NewVMDlg):
 
         properties = {}
         properties['provides_network'] = self.provides_network.isChecked()
-        properties['netvm'] = self.netvm_list[self.netvm.currentIndex()]
+        if self.netvm.currentIndex() != 0:
+            properties['netvm'] = self.netvm_list[self.netvm.currentIndex()]
         if self.install_system.isChecked():
             properties['virt_mode'] = 'hvm'
             properties['kernel'] = None


### PR DESCRIPTION
To avoid conflict with scripts that make whonix magic,
if the user selects default netvm, we do not set any  netvm and
trust the create_vm method to properly set it as default appropriate
for the given template.

fixes QubesOS/qubes-issues#1954