### PR TITLE
Tab Order Cleanup

### DIFF
--- a/ui/backupdlg.ui
+++ b/ui/backupdlg.ui
@@ -421,6 +421,18 @@ p, li { white-space: pre-wrap; }
    </layout>
   </widget>
  </widget>
+ <tabstops>
+  <tabstop>compress_checkbox</tabstop>
+  <tabstop>appvm_combobox</tabstop>
+  <tabstop>dir_line_edit</tabstop>
+  <tabstop>select_path_button</tabstop>
+  <tabstop>passphrase_line_edit</tabstop>
+  <tabstop>passphrase_line_edit_verify</tabstop>
+  <tabstop>save_profile_checkbox</tabstop>
+  <tabstop>turn_off_checkbox</tabstop>
+  <tabstop>textEdit</tabstop>
+  <tabstop>showFileDialog</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources.qrc"/>
  </resources>

--- a/ui/devicelist.ui
+++ b/ui/devicelist.ui
@@ -77,6 +77,10 @@
    </property>
   </widget>
  </widget>
+ <tabstops>
+  <tabstop>device_list</tabstop>
+  <tabstop>buttonBox</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/ui/globalsettingsdlg.ui
+++ b/ui/globalsettingsdlg.ui
@@ -248,6 +248,21 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>update_vm_combo</tabstop>
+  <tabstop>clock_vm_combo</tabstop>
+  <tabstop>default_netvm_combo</tabstop>
+  <tabstop>default_template_combo</tabstop>
+  <tabstop>default_dispvm_combo</tabstop>
+  <tabstop>min_vm_mem</tabstop>
+  <tabstop>dom0_mem_boost</tabstop>
+  <tabstop>default_kernel_combo</tabstop>
+  <tabstop>updates_dom0</tabstop>
+  <tabstop>updates_vm</tabstop>
+  <tabstop>disable_updates_all</tabstop>
+  <tabstop>enable_updates_all</tabstop>
+  <tabstop>buttonBox</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/ui/newappvmdlg.ui
+++ b/ui/newappvmdlg.ui
@@ -140,7 +140,13 @@
  </widget>
  <tabstops>
   <tabstop>name</tabstop>
+  <tabstop>label</tabstop>
+  <tabstop>vm_type</tabstop>
   <tabstop>template_vm</tabstop>
+  <tabstop>netvm</tabstop>
+  <tabstop>provides_network</tabstop>
+  <tabstop>launch_settings</tabstop>
+  <tabstop>install_system</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>

--- a/ui/newfwruledlg.ui
+++ b/ui/newfwruledlg.ui
@@ -144,6 +144,11 @@
   </layout>
  </widget>
  <tabstops>
+  <tabstop>addressComboBox</tabstop>
+  <tabstop>serviceComboBox</tabstop>
+  <tabstop>tcp_radio</tabstop>
+  <tabstop>udp_radio</tabstop>
+  <tabstop>any_radio</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>

--- a/ui/restoredlg.ui
+++ b/ui/restoredlg.ui
@@ -268,6 +268,19 @@ p, li { white-space: pre-wrap; }
    </layout>
   </widget>
  </widget>
+ <tabstops>
+  <tabstop>appvm_combobox</tabstop>
+  <tabstop>dir_line_edit</tabstop>
+  <tabstop>select_path_button</tabstop>
+  <tabstop>ignore_missing</tabstop>
+  <tabstop>verify_only</tabstop>
+  <tabstop>ignore_uname_mismatch</tabstop>
+  <tabstop>encryption_checkbox</tabstop>
+  <tabstop>passphrase_line_edit</tabstop>
+  <tabstop>confirm_text_edit</tabstop>
+  <tabstop>commit_text_edit</tabstop>
+  <tabstop>showFileDialog</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/ui/settingsdlg.ui
+++ b/ui/settingsdlg.ui
@@ -1411,8 +1411,8 @@ The qube must be running to disable seamless mode; this setting is not persisten
   </layout>
  </widget>
  <tabstops>
-  <tabstop>tabWidget</tabstop>
   <tabstop>vmname</tabstop>
+  <tabstop>rename_vm_button</tabstop>
   <tabstop>vmlabel</tabstop>
   <tabstop>template_name</tabstop>
   <tabstop>netVM</tabstop>
@@ -1420,20 +1420,35 @@ The qube must be running to disable seamless mode; this setting is not persisten
   <tabstop>run_in_debug_mode</tabstop>
   <tabstop>autostart_vm</tabstop>
   <tabstop>max_priv_storage</tabstop>
+  <tabstop>root_resize</tabstop>
+  <tabstop>delete_vm_button</tabstop>
+  <tabstop>clone_vm_button</tabstop>
   <tabstop>init_mem</tabstop>
   <tabstop>max_mem_size</tabstop>
   <tabstop>vcpus</tabstop>
   <tabstop>include_in_balancing</tabstop>
+  <tabstop>default_dispvm</tabstop>
+  <tabstop>boot_from_device_button</tabstop>
+  <tabstop>seamless_on_button</tabstop>
+  <tabstop>seamless_off_button</tabstop>
   <tabstop>kernel</tabstop>
-  <tabstop>new_rule_button</tabstop>
+  <tabstop>virt_mode</tabstop>
+  <tabstop>policy_allow_radio_button</tabstop>
+  <tabstop>policy_deny_radio_button</tabstop>
   <tabstop>rulesTreeView</tabstop>
+  <tabstop>new_rule_button</tabstop>
   <tabstop>edit_rule_button</tabstop>
   <tabstop>delete_rule_button</tabstop>
+  <tabstop>temp_full_access</tabstop>
+  <tabstop>temp_full_access_time</tabstop>
+  <tabstop>no_strict_reset_button</tabstop>
+  <tabstop>refresh_apps_button</tabstop>
   <tabstop>service_line_edit</tabstop>
   <tabstop>add_srv_button</tabstop>
-  <tabstop>services_list</tabstop>
   <tabstop>remove_srv_button</tabstop>
+  <tabstop>services_list</tabstop>
   <tabstop>buttonBox</tabstop>
+  <tabstop>tabWidget</tabstop>
  </tabstops>
  <resources>
   <include location="../resources.qrc"/>


### PR DESCRIPTION
Fixed tab order in multiple widgets: Backup, Global Settings,
Create New Qube, Settings, Restore.

fixes QubesOS/qubes-issues#4746