### PR TITLE
Added "set as dvm template" to VM settings

### DIFF
--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -704,6 +704,11 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
         self.seamless_on_button.clicked.connect(self.enable_seamless)
         self.seamless_off_button.clicked.connect(self.disable_seamless)
 
+        if hasattr(self.vm, "template_for_dispvms"):
+            self.dvm_template_checkbox.setChecked(self.vm.template_for_dispvms)
+        else:
+            self.dvm_template_checkbox.setVisible(False)
+
     def enable_seamless(self):
         self.vm.run_service_for_stdio("qubes.SetGuiMode", input=b'SEAMLESS')
 
@@ -758,6 +763,18 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
                 self.vm.virt_mode = self.selected_virt_mode()
         except Exception as ex:  # pylint: disable=broad-except
             msg.append(str(ex))
+
+        if getattr(self.vm, "template_for_dispvms", False) != \
+                self.dvm_template_checkbox.isChecked():
+            try:
+                self.vm.template_for_dispvms = \
+                    self.dvm_template_checkbox.isChecked()
+                if self.dvm_template_checkbox.isChecked():
+                    self.vm.features["appmenus-dispvm"] = True
+                else:
+                    del self.vm.features["appmenus-dispvm"]
+            except Exception as ex:  # pylint: disable=broad-except
+                msg.append(str(ex))
 
         return msg
 

--- a/ui/settingsdlg.ui
+++ b/ui/settingsdlg.ui
@@ -779,7 +779,7 @@ border-width: 1px;</string>
             <property name="topMargin">
              <number>15</number>
             </property>
-            <item row="1" column="0">
+            <item row="2" column="0">
              <widget class="QLabel" name="label_26">
               <property name="text">
                <string>Default DispVM:</string>
@@ -789,17 +789,17 @@ border-width: 1px;</string>
               </property>
              </widget>
             </item>
-            <item row="1" column="1">
+            <item row="2" column="1">
              <widget class="QComboBox" name="default_dispvm"/>
             </item>
-            <item row="2" column="0" colspan="2">
+            <item row="3" column="0" colspan="2">
              <widget class="QPushButton" name="boot_from_device_button">
               <property name="text">
                <string>Boot qube from CDROM</string>
               </property>
              </widget>
             </item>
-            <item row="3" column="0" colspan="2">
+            <item row="4" column="0" colspan="2">
              <layout class="QHBoxLayout" name="horizontalLayout_8">
               <item>
                <widget class="QPushButton" name="seamless_on_button">
@@ -824,6 +824,16 @@ The qube must be running to disable seamless mode; this setting is not persisten
                </widget>
               </item>
              </layout>
+            </item>
+            <item row="1" column="0" colspan="2">
+             <widget class="QCheckBox" name="dvm_template_checkbox">
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>Allow starting DisposableVMs from this qube</string>
+              </property>
+             </widget>
             </item>
            </layout>
           </widget>


### PR DESCRIPTION
Added an 'Advanced' settings checkbox that allows the user to set a given
VM as template fo dispvms. It sets both the template_for_dispvms property
and the appmenus-dispvm feature - instead of delving into particulars
of how and which should be set, the user can just turn off the
whole setting if they want to make some changes in the vm and then turn
it on again.

fixes QubesOS/qubes-issues#4004