### PR TITLE
Fixed minor error in Qubes Backup

### DIFF
--- a/qubesmanager/utils.py
+++ b/qubesmanager/utils.py
@@ -163,6 +163,8 @@ def get_path_from_vm(vm, service_name):
         return None
     stdout, _stderr = vm.run_service_for_stdio(service_name)
 
+    stdout = stdout.strip()
+
     untrusted_path = stdout.decode(encoding='ascii')[:path_max_len]
 
     if not untrusted_path:


### PR DESCRIPTION
Possibly due to changes in how services work,
the run_service_for_stdio was returning path with trailing
whitespace.

fixes QubesOS/qubes-issues#4921