### PR TITLE
Fixed device list behavior for a running VM in VM settings

### DIFF
--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -966,6 +966,8 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
 
         self.update_pvh_dont_support_devs()
 
+        self.dev_list.setEnabled(not self.vm.is_running())
+
     def __apply_devices_tab__(self):
         msg = []
 


### PR DESCRIPTION
PCI devices will now correctly be unmodifiable if the VM is running.

fixes QubesOS/qubes-issues#4933