### PR TITLE
Add UI for managing Qubes update repositories

### DIFF
--- a/qubesmanager/global_settings.py
+++ b/qubesmanager/global_settings.py
@@ -37,6 +37,51 @@ from configparser import ConfigParser
 
 qmemman_config_path = '/etc/qubes/qmemman.conf'
 
+def _run_qrexec_repo(service, arg=''):
+    # Fake up a "qrexec call" to dom0 because dom0 can't qrexec to itself yet
+    cmd = '/etc/qubes-rpc/' + service
+    p = subprocess.run(
+        ['sudo', cmd, arg],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+    )
+    assert not p.stderr
+    assert p.returncode == 0
+    return p.stdout.decode('utf-8')
+
+def _manage_repos(repolist, action):
+    for i in repolist:
+        assert _run_qrexec_repo('qubes.repos.' + action, i) == 'ok\n'
+
+def _handle_dom0_updates_combobox(idx):
+    idx += 1
+    repolist = ['qubes-dom0-current', 'qubes-dom0-security-testing',
+         'qubes-dom0-current-testing', 'qubes-dom0-unstable']
+    enable = repolist[:idx]
+    disable = repolist[idx:]
+    _manage_repos(enable, 'Enable')
+    _manage_repos(disable, 'Disable')
+
+# pylint: disable=invalid-name
+def _handle_itl_tmpl_updates_combobox(idx):
+    idx += 1
+    repolist = ['qubes-templates-itl', 'qubes-templates-itl-testing']
+    enable = repolist[:idx]
+    disable = repolist[idx:]
+    _manage_repos(enable, 'Enable')
+    _manage_repos(disable, 'Disable')
+
+# pylint: disable=invalid-name
+def _handle_comm_tmpl_updates_combobox(idx):
+    # We don't increment idx by 1 because this is the only combobox that
+    # has an explicit "disable this repository entirely" option
+    repolist = ['qubes-templates-community',
+                'qubes-templates-community-testing']
+    enable = repolist[:idx]
+    disable = repolist[idx:]
+    _manage_repos(enable, 'Enable')
+    _manage_repos(disable, 'Disable')
+
 # pylint: disable=too-many-instance-attributes
 class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
                            QtGui.QDialog):
@@ -234,14 +279,6 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
                 qmemman_config_file.writelines(config_lines)
                 qmemman_config_file.close()
 
-    def __run_qrexec_repo(self, service, arg=''):
-        # Fake up a "qrexec call" to dom0 because dom0 can't qrexec to itself yet
-        cmd = '/etc/qubes-rpc/' + service
-        p = subprocess.run(['sudo', cmd, arg], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        assert not p.stderr
-        assert p.returncode == 0
-        return p.stdout.decode('utf-8')
-
     def __init_updates__(self):
         # TODO: remove workaround when it is no longer needed
         self.dom0_updates_file_path = '/var/lib/qubes/updates/disable-updates'
@@ -260,12 +297,12 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
         self.disable_updates_all.clicked.connect(self.__disable_updates_all)
 
         repos = dict()
-        for i in self.__run_qrexec_repo('qubes.repos.List').split('\n'):
+        for i in _run_qrexec_repo('qubes.repos.List').split('\n'):
             l = i.split('\0')
             # Keyed by repo name
             d = repos[l[0]] = dict()
             d['prettyname'] = l[1]
-            d['enabled'] = True if l[2] == 'enabled' else False
+            d['enabled'] = l[2] == 'enabled'
 
         if repos['qubes-dom0-unstable']['enabled']:
             self.dom0_updates_repo.setCurrentIndex(3)
@@ -283,7 +320,8 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
         elif repos['qubes-templates-itl']['enabled']:
             self.itl_tmpl_updates_repo.setCurrentIndex(0)
         else:
-            raise Exception('Cannot detect enabled ITL template update repositories')
+            raise Exception('Cannot detect enabled ITL template update '
+                            'repositories')
 
         if repos['qubes-templates-community-testing']['enabled']:
             self.comm_tmpl_updates_repo.setCurrentIndex(2)
@@ -292,39 +330,15 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
         else:
             self.comm_tmpl_updates_repo.setCurrentIndex(0)
 
-        self.dom0_updates_repo.currentIndexChanged.connect(self.__handle_dom0_updates_combobox)
-        self.itl_tmpl_updates_repo.currentIndexChanged.connect(self.__handle_itl_tmpl_updates_combobox)
-        self.comm_tmpl_updates_repo.currentIndexChanged.connect(self.__handle_comm_tmpl_updates_combobox)
-
-    def __manage_repos(self, l, action):
-        for i in l:
-            assert self.__run_qrexec_repo('qubes.repos.' + action, i) == 'ok\n'
-
-    def __handle_dom0_updates_combobox(self, idx):
-        idx += 1
-        l = ['qubes-dom0-current', 'qubes-dom0-security-testing',
-             'qubes-dom0-current-testing', 'qubes-dom0-unstable']
-        enable = l[:idx]
-        disable = l[idx:]
-        self.__manage_repos(enable, 'Enable')
-        self.__manage_repos(disable, 'Disable')
-
-    def __handle_itl_tmpl_updates_combobox(self, idx):
-        idx += 1
-        l = ['qubes-templates-itl', 'qubes-templates-itl-testing']
-        enable = l[:idx]
-        disable = l[idx:]
-        self.__manage_repos(enable, 'Enable')
-        self.__manage_repos(disable, 'Disable')
-
-    def __handle_comm_tmpl_updates_combobox(self, idx):
-        # We don't increment idx by 1 because this is the only combobox that
-        # has an explicit "disable this repository entirely" option
-        l = ['qubes-templates-community', 'qubes-templates-community-testing']
-        enable = l[:idx]
-        disable = l[idx:]
-        self.__manage_repos(enable, 'Enable')
-        self.__manage_repos(disable, 'Disable')
+        self.dom0_updates_repo.currentIndexChanged.connect(
+            _handle_dom0_updates_combobox
+        )
+        self.itl_tmpl_updates_repo.currentIndexChanged.connect(
+            _handle_itl_tmpl_updates_combobox
+        )
+        self.comm_tmpl_updates_repo.currentIndexChanged.connect(
+            _handle_comm_tmpl_updates_combobox
+        )
 
     def __enable_updates_all(self):
         reply = QtGui.QMessageBox.question(

--- a/qubesmanager/global_settings.py
+++ b/qubesmanager/global_settings.py
@@ -47,7 +47,7 @@ def _run_qrexec_repo(service, arg=''):
     )
     if p.stderr:
         raise RuntimeError('qrexec call stderr was not empty',
-                           {'stderr': p.stderr})
+                           {'stderr': p.stderr.decode('utf-8')})
     if p.returncode != 0:
         raise RuntimeError('qrexec call exited with non-zero return code',
                            {'returncode': p.returncode})

--- a/qubesmanager/global_settings.py
+++ b/qubesmanager/global_settings.py
@@ -359,8 +359,8 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
                 QtGui.QMessageBox.warning(
                     None,
                     self.tr("ERROR!"),
-                    self.tr("Error managing repository settings: {msg}".format(
-                        msg=msg)))
+                    self.tr("Error managing {repo} repository settings:"
+                            " {msg}".format(repo=name, msg=msg)))
 
     def _handle_dom0_updates_combobox(self, idx):
         idx += 1

--- a/qubesmanager/global_settings.py
+++ b/qubesmanager/global_settings.py
@@ -51,7 +51,7 @@ def _run_qrexec_repo(service, arg=''):
 
 def _manage_repos(repolist, action):
     for i in repolist:
-        assert _run_qrexec_repo('qubes.repos.' + action, i) == 'ok\n'
+        _run_qrexec_repo('qubes.repos.' + action, i) == 'ok\n'
 
 def _handle_dom0_updates_combobox(idx):
     idx += 1

--- a/qubesmanager/global_settings.py
+++ b/qubesmanager/global_settings.py
@@ -344,16 +344,6 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
         else:
             self.comm_tmpl_updates_repo.setCurrentIndex(0)
 
-        self.dom0_updates_repo.currentIndexChanged.connect(
-            _handle_dom0_updates_combobox
-        )
-        self.itl_tmpl_updates_repo.currentIndexChanged.connect(
-            _handle_itl_tmpl_updates_combobox
-        )
-        self.comm_tmpl_updates_repo.currentIndexChanged.connect(
-            _handle_comm_tmpl_updates_combobox
-        )
-
     def __enable_updates_all(self):
         reply = QtGui.QMessageBox.question(
             self, self.tr("Change state of all qubes"),
@@ -390,6 +380,14 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
         if self.qvm_collection.check_updates_vm != self.updates_vm.isChecked():
             self.qvm_collection.check_updates_vm = self.updates_vm.isChecked()
 
+    def __apply_repos__(self):
+        _handle_dom0_updates_combobox(
+            self.dom0_updates_repo.currentIndex())
+        _handle_itl_tmpl_updates_combobox(
+            self.itl_tmpl_updates_repo.currentIndex())
+        _handle_comm_tmpl_updates_combobox(
+            self.comm_tmpl_updates_repo.currentIndex())
+
     def reject(self):
         self.done(0)
 
@@ -399,8 +397,7 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
         self.__apply_kernel_defaults__()
         self.__apply_mem_defaults__()
         self.__apply_updates__()
-
-
+        self.__apply_repos__()
 
 # Bases on the original code by:
 # Copyright (c) 2002-2007 Pascal Varet <p.varet@gmail.com>

--- a/qubesmanager/global_settings.py
+++ b/qubesmanager/global_settings.py
@@ -269,11 +269,11 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
 
         repos = dict()
         for i in _run_qrexec_repo('qubes.repos.List').split('\n'):
-            l = i.split('\0')
+            lst = i.split('\0')
             # Keyed by repo name
-            d = repos[l[0]] = dict()
-            d['prettyname'] = l[1]
-            d['enabled'] = l[2] == 'enabled'
+            dct = repos[lst[0]] = dict()
+            dct['prettyname'] = lst[1]
+            dct['enabled'] = lst[2] == 'enabled'
 
         if repos['qubes-dom0-unstable']['enabled']:
             self.dom0_updates_repo.setCurrentIndex(3)

--- a/qubesmanager/global_settings.py
+++ b/qubesmanager/global_settings.py
@@ -51,7 +51,8 @@ def _run_qrexec_repo(service, arg=''):
 
 def _manage_repos(repolist, action):
     for i in repolist:
-        _run_qrexec_repo('qubes.repos.' + action, i) == 'ok\n'
+        result = _run_qrexec_repo('qubes.repos.' + action, i)
+        assert result == 'ok\n'
 
 def _handle_dom0_updates_combobox(idx):
     idx += 1

--- a/qubesmanager/global_settings.py
+++ b/qubesmanager/global_settings.py
@@ -267,7 +267,7 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
         self.enable_updates_all.clicked.connect(self.__enable_updates_all)
         self.disable_updates_all.clicked.connect(self.__disable_updates_all)
 
-        repos = dict()
+        self.repos = repos = dict()
         for i in _run_qrexec_repo('qubes.repos.List').split('\n'):
             lst = i.split('\0')
             # Keyed by repo name
@@ -338,9 +338,13 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
             self.qvm_collection.check_updates_vm = self.updates_vm.isChecked()
 
     def _manage_repos(self, repolist, action):
-        for i in repolist:
+        for name in repolist:
+            if self.repos[name]['enabled'] and action == 'Enable' or \
+               not self.repos[name]['enabled'] and action == 'Disable':
+                continue
+
             try:
-                result = _run_qrexec_repo('qubes.repos.' + action, i)
+                result = _run_qrexec_repo('qubes.repos.' + action, name)
                 if result != 'ok\n':
                     raise RuntimeError(
                         'qrexec call stdout did not contain "ok" as expected',

--- a/qubesmanager/global_settings.py
+++ b/qubesmanager/global_settings.py
@@ -52,50 +52,6 @@ def _run_qrexec_repo(service, arg=''):
                            returncode=p.returncode)
     return p.stdout.decode('utf-8')
 
-def _manage_repos(repolist, action):
-    for i in repolist:
-        try:
-            result = _run_qrexec_repo('qubes.repos.' + action, i)
-            if result != 'ok\n':
-                raise RuntimeError(
-                    'qrexec call stdout did not contain "ok" as expected',
-                    result=result)
-        except RuntimeError as ex:
-            QtGui.QMessageBox.warning(
-                None,
-                self.tr("ERROR!"),
-                self.tr("Error managing repository settings: {e}".format(
-                    e=str(ex))))
-
-def _handle_dom0_updates_combobox(idx):
-    idx += 1
-    repolist = ['qubes-dom0-current', 'qubes-dom0-security-testing',
-         'qubes-dom0-current-testing', 'qubes-dom0-unstable']
-    enable = repolist[:idx]
-    disable = repolist[idx:]
-    _manage_repos(enable, 'Enable')
-    _manage_repos(disable, 'Disable')
-
-# pylint: disable=invalid-name
-def _handle_itl_tmpl_updates_combobox(idx):
-    idx += 1
-    repolist = ['qubes-templates-itl', 'qubes-templates-itl-testing']
-    enable = repolist[:idx]
-    disable = repolist[idx:]
-    _manage_repos(enable, 'Enable')
-    _manage_repos(disable, 'Disable')
-
-# pylint: disable=invalid-name
-def _handle_comm_tmpl_updates_combobox(idx):
-    # We don't increment idx by 1 because this is the only combobox that
-    # has an explicit "disable this repository entirely" option
-    repolist = ['qubes-templates-community',
-                'qubes-templates-community-testing']
-    enable = repolist[:idx]
-    disable = repolist[idx:]
-    _manage_repos(enable, 'Enable')
-    _manage_repos(disable, 'Disable')
-
 # pylint: disable=too-many-instance-attributes
 class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
                            QtGui.QDialog):
@@ -380,12 +336,56 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
         if self.qvm_collection.check_updates_vm != self.updates_vm.isChecked():
             self.qvm_collection.check_updates_vm = self.updates_vm.isChecked()
 
+    def _manage_repos(self, repolist, action):
+        for i in repolist:
+            try:
+                result = _run_qrexec_repo('qubes.repos.' + action, i)
+                if result != 'ok\n':
+                    raise RuntimeError(
+                        'qrexec call stdout did not contain "ok" as expected',
+                        result=result)
+            except RuntimeError as ex:
+                QtGui.QMessageBox.warning(
+                    None,
+                    self.tr("ERROR!"),
+                    self.tr("Error managing repository settings: {e}".format(
+                        e=str(ex))))
+
+    def _handle_dom0_updates_combobox(self, idx):
+        idx += 1
+        repolist = ['qubes-dom0-current', 'qubes-dom0-security-testing',
+                    'qubes-dom0-current-testing', 'qubes-dom0-unstable']
+        enable = repolist[:idx]
+        disable = repolist[idx:]
+        self._manage_repos(enable, 'Enable')
+        self._manage_repos(disable, 'Disable')
+
+    # pylint: disable=invalid-name
+    def _handle_itl_tmpl_updates_combobox(self, idx):
+        idx += 1
+        repolist = ['qubes-templates-itl', 'qubes-templates-itl-testing']
+        enable = repolist[:idx]
+        disable = repolist[idx:]
+        self._manage_repos(enable, 'Enable')
+        self._manage_repos(disable, 'Disable')
+
+    # pylint: disable=invalid-name
+    def _handle_comm_tmpl_updates_combobox(self, idx):
+        # We don't increment idx by 1 because this is the only combobox that
+        # has an explicit "disable this repository entirely" option
+        repolist = ['qubes-templates-community',
+                    'qubes-templates-community-testing']
+        enable = repolist[:idx]
+        disable = repolist[idx:]
+        self._manage_repos(enable, 'Enable')
+        self._manage_repos(disable, 'Disable')
+
     def __apply_repos__(self):
-        _handle_dom0_updates_combobox(
+        self._handle_dom0_updates_combobox(
             self.dom0_updates_repo.currentIndex())
-        _handle_itl_tmpl_updates_combobox(
+        self._handle_itl_tmpl_updates_combobox(
             self.itl_tmpl_updates_repo.currentIndex())
-        _handle_comm_tmpl_updates_combobox(
+        self._handle_comm_tmpl_updates_combobox(
             self.comm_tmpl_updates_repo.currentIndex())
 
     def reject(self):

--- a/qubesmanager/global_settings.py
+++ b/qubesmanager/global_settings.py
@@ -46,10 +46,11 @@ def _run_qrexec_repo(service, arg=''):
         stderr=subprocess.PIPE
     )
     if p.stderr:
-        raise RuntimeError('qrexec call stderr was not empty', stderr=p.stderr)
+        raise RuntimeError('qrexec call stderr was not empty',
+                           {'stderr': p.stderr})
     if p.returncode != 0:
         raise RuntimeError('qrexec call exited with non-zero return code',
-                           returncode=p.returncode)
+                           {'returncode': p.returncode})
     return p.stdout.decode('utf-8')
 
 # pylint: disable=too-many-instance-attributes
@@ -343,13 +344,19 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
                 if result != 'ok\n':
                     raise RuntimeError(
                         'qrexec call stdout did not contain "ok" as expected',
-                        result=result)
+                        {'stdout': result})
             except RuntimeError as ex:
+                msg = '{desc}; {args}'.format(desc=ex.args[0], args=', '.join(
+                      # This is kind of hard to mentally parse but really all
+                      # it does is pretty-print args[1], which is a dictionary
+                      ['{key}: {val}'.format(key=i[0], val=i[1]) for i in
+                       ex.args[1].items()]
+                ))
                 QtGui.QMessageBox.warning(
                     None,
                     self.tr("ERROR!"),
-                    self.tr("Error managing repository settings: {e}".format(
-                        e=str(ex))))
+                    self.tr("Error managing repository settings: {msg}".format(
+                        msg=msg)))
 
     def _handle_dom0_updates_combobox(self, idx):
         idx += 1

--- a/qubesmanager/global_settings.py
+++ b/qubesmanager/global_settings.py
@@ -104,7 +104,7 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
             )
 
     def __apply_system_defaults__(self):
-        # upatevm
+        # updatevm
         if self.qvm_collection.updatevm != \
                 self.update_vm_vmlist[self.update_vm_combo.currentIndex()]:
             self.qvm_collection.updatevm = \

--- a/ui/globalsettingsdlg.ui
+++ b/ui/globalsettingsdlg.ui
@@ -98,7 +98,7 @@
      </layout>
     </widget>
    </item>
-   <item row="3" column="0" colspan="2">
+   <item row="4" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -209,6 +209,30 @@
       <string>Updates</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
+      <item row="1" column="0">
+       <widget class="QComboBox" name="dom0_updates_repo">
+        <item>
+         <property name="text">
+          <string>Stable updates</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Testing updates (security only)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Testing updates</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Unstable updates</string>
+         </property>
+        </item>
+       </widget>
+      </item>
       <item row="1" column="1">
        <widget class="QPushButton" name="disable_updates_all">
         <property name="text">
@@ -241,6 +265,39 @@
         <property name="text">
          <string>Enable checking for updates for all qubes</string>
         </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QComboBox" name="itl_tmpl_updates_repo">
+        <item>
+         <property name="text">
+          <string>ITL template updates</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>ITL template updates (testing)</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QComboBox" name="comm_tmpl_updates_repo">
+        <item>
+         <property name="text">
+          <string>(Community templates disabled)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Community template updates</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Community template updates (testing)</string>
+         </property>
+        </item>
        </widget>
       </item>
      </layout>


### PR DESCRIPTION
Screenshot:

![Screenshot_2019-04-08_03-24-50](https://user-images.githubusercontent.com/911174/55705933-eeac6300-59ad-11e9-8f9b-c5aba716de19.png)


Menu options provided:

* Stable updates
* Testing updates (security only)
* Testing updates
* Unstable updates
---
* ITL template updates
* ITL template updates (testing)
---
* (Community templates disabled)
* Community template updates
* Community template updates (testing)

I'll fix the TODO in the PR with the qrexec services and then delete the hack in this code. But since the rest of this is complete I figured I'd open a PR and get the ball rolling on code review.

Depends on QubesOS/qubes-core-admin-linux#48

Fixes QubesOS/qubes-issues#4550