### PR TITLE
Made terminology in Create New VM GUI clearer

### DIFF
--- a/qubesmanager/create_new_vm.py
+++ b/qubesmanager/create_new_vm.py
@@ -117,9 +117,9 @@ class NewVmDlg(QtGui.QDialog, Ui_NewVMDlg):
 
         # Order of types is important and used elsewhere; if it's changed
         # check for changes needed in self.type_change and TODO
-        type_list = [self.tr("AppVM"),
-                     self.tr("Standalone qube based on a template"),
-                     self.tr("Standalone qube not based on a template")]
+        type_list = [self.tr("Qube based on a template (AppVM)"),
+                     self.tr("Standalone qube"),
+                     self.tr("Standalone qube copied from a template")]
         self.vm_type.addItems(type_list)
 
         self.vm_type.currentIndexChanged.connect(self.type_change)

--- a/qubesmanager/create_new_vm.py
+++ b/qubesmanager/create_new_vm.py
@@ -116,10 +116,10 @@ class NewVmDlg(QtGui.QDialog, Ui_NewVMDlg):
                 self.tr('Cannot create a qube when no template exists.'))
 
         # Order of types is important and used elsewhere; if it's changed
-        # check for changes needed in self.type_change and TODO
+        # check for changes needed in self.type_change
         type_list = [self.tr("Qube based on a template (AppVM)"),
-                     self.tr("Standalone qube"),
-                     self.tr("Standalone qube copied from a template")]
+                     self.tr("Standalone qube copied from a template"),
+                     self.tr("Empty standalone qube (install your own OS)")]
         self.vm_type.addItems(type_list)
 
         self.vm_type.currentIndexChanged.connect(self.type_change)


### PR DESCRIPTION
Changed the terms used in Create New VM Gui to the following:
-Qube based on a template (AppVM)
-Standalone qube
-Standalone qube copied from a template

references QubesOS/qubes-issues#4723