### PR TITLE
treat kali-* as a variant of buster/sid

### DIFF
--- a/qubesmanager/dsa-4371-update
+++ b/qubesmanager/dsa-4371-update
@@ -58,7 +58,7 @@ main() {
 
     codename="$(cat /etc/debian_version)"
     case "$codename" in
-        */sid)
+        */sid|kali-*)
             # We will treat testing as sid here. This hopefully won't break
             # anything ...
             codename="sid"


### PR DESCRIPTION
kali /etc/debian_version is "kali-rolling".
debian-10 /etc/debian_version is "buster/sid".

kali-rolling is currently based on buster.
the qubes-manager check doesnt have a buster branch right now, but is matching that as */sid.

not really sure this is the right way to go (why are we not matching the "buster" part?), but this works-for-me for updating both debian-10 and kali templates. 
