### PR TITLE
Added menu position with Qubes Tools to XFCE Menu

### DIFF
--- a/qubes-backup-restore.desktop
+++ b/qubes-backup-restore.desktop
@@ -6,4 +6,4 @@ Terminal=false
 Name=Restore Backup
 GenericName=Restore Backup
 StartupNotify=false
-Categories=System;
+Categories=Settings;X-XFCE-SettingsDialog

--- a/qubes-backup.desktop
+++ b/qubes-backup.desktop
@@ -6,4 +6,4 @@ Terminal=false
 Name=Backup Qubes
 GenericName=Backup Qubes
 StartupNotify=false
-Categories=System;
+Categories=Settings;X-XFCE-SettingsDialog

--- a/qubes-global-settings.desktop
+++ b/qubes-global-settings.desktop
@@ -6,4 +6,4 @@ Terminal=false
 Name=Qubes Global Settings
 GenericName=Qubes Global Settings
 StartupNotify=false
-Categories=System;
+Categories=Settings;X-XFCE-SettingsDialog

--- a/qubes-qube-manager.desktop
+++ b/qubes-qube-manager.desktop
@@ -6,4 +6,4 @@ Terminal=false
 Name=Qube Manager
 GenericName=Qube Manager
 StartupNotify=false
-Categories=System;
+Categories=Settings;X-XFCE-SettingsDialog

--- a/qubes-template-manager.desktop
+++ b/qubes-template-manager.desktop
@@ -6,4 +6,4 @@ Terminal=false
 Name=Qubes Template Manager
 GenericName=Qubes Template Manager
 StartupNotify=false
-Categories=System;
+Categories=Settings;X-XFCE-SettingsDialog

--- a/qubes-tools.directory
+++ b/qubes-tools.directory
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Type=Directory
+Icon=qubes-manager
+
+Name=Qubes Tools
+GenericName=Qubes Tools

--- a/qubes-tools.menu
+++ b/qubes-tools.menu
@@ -1,0 +1,17 @@
+<!DOCTYPE Menu PUBLIC "-//freedesktop//DTD Menu 1.0//EN"
+"http://www.freedesktop.org/standards/menu-spec/menu-1.0.dtd">
+<Menu>
+    <Name>Applications</Name>
+        <Menu>
+          <Name>Qubes Tools</Name>
+          <Directory>qubes-tools.directory</Directory>
+          <Include>
+            <Filename>qubes-vm-create.desktop</Filename>
+            <Filename>qubes-backup.desktop</Filename>
+            <Filename>qubes-backup-restore.desktop</Filename>
+            <Filename>qubes-global-settings.desktop</Filename>
+            <Filename>qubes-qube-manager.desktop</Filename>
+            <Filename>qubes-template-manager.desktop</Filename>
+          </Include>
+        </Menu>
+</Menu>

--- a/qubes-vm-create.desktop
+++ b/qubes-vm-create.desktop
@@ -7,4 +7,4 @@ Terminal=false
 Name=Create Qubes VM
 GenericName=Create Qubes VM
 StartupNotify=false
-Categories=System;X-Xfce-Toplevel;
+Categories=Settings;X-XFCE-SettingsDialog

--- a/rpm_spec/qmgr.spec.in
+++ b/rpm_spec/qmgr.spec.in
@@ -51,6 +51,12 @@ cp qubes-backup-restore.desktop $RPM_BUILD_ROOT/usr/share/applications/
 cp qubes-qube-manager.desktop $RPM_BUILD_ROOT/usr/share/applications/
 cp qubes-template-manager.desktop $RPM_BUILD_ROOT/usr/share/applications/
 
+mkdir -p $RPM_BUILD_ROOT/usr/share/desktop-directories/
+cp qubes-tools.directory $RPM_BUILD_ROOT/usr/share/desktop-directories/
+
+mkdir -p $RPM_BUILD_ROOT/etc/xdg/menus/applications-merged/
+cp qubes-tools.menu $RPM_BUILD_ROOT/etc/xdg/menus/applications-merged/
+
 %post
 update-desktop-database &> /dev/null || :
 
@@ -136,6 +142,8 @@ rm -rf $RPM_BUILD_ROOT
 /usr/share/applications/qubes-backup-restore.desktop
 /usr/share/applications/qubes-qube-manager.desktop
 /usr/share/applications/qubes-template-manager.desktop
+/usr/share/desktop-directories/qubes-tools.directory
+/etc/xdg/menus/applications-merged/qubes-tools.menu
 
 %changelog
 @CHANGELOG@


### PR DESCRIPTION
Added a menu directory with Qubes tools (to make them easier to find)
and also adds Qubes tools to XFCE settings manager.
Requires https://github.com/QubesOS/qubes-desktop-linux-xfce4/pull/14