### PR TITLE
Added 'provides network' checkbox to VM settings

### DIFF
--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -745,6 +745,17 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
         else:
             self.dvm_template_checkbox.setVisible(False)
 
+        self.provides_network_checkbox.setChecked(
+            getattr(self.vm, 'provides_network', False))
+        if self.provides_network_checkbox.isChecked():
+            domains_using = [vm.name for vm in self.vm.connected_vms]
+            if domains_using:
+                self.provides_network_checkbox.setEnabled(False)
+                self.provides_network_checkbox.setToolTip(
+                    "Cannot change this setting while this qube is used as a "
+                    "NetVM by the following qubes:\n" +
+                    "\n".join(domains_using))
+
     def enable_seamless(self):
         self.vm.run_service_for_stdio("qubes.SetGuiMode", input=b'SEAMLESS')
 
@@ -812,6 +823,14 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
                     self.vm.features["appmenus-dispvm"] = True
                 else:
                     del self.vm.features["appmenus-dispvm"]
+            except Exception as ex:  # pylint: disable=broad-except
+                msg.append(str(ex))
+
+        if getattr(self.vm, 'provides_network', False) != \
+                self.provides_network_checkbox.isChecked():
+            try:
+                self.vm.provides_network = \
+                    self.provides_network_checkbox.isChecked()
             except Exception as ex:  # pylint: disable=broad-except
                 msg.append(str(ex))
 

--- a/ui/settingsdlg.ui
+++ b/ui/settingsdlg.ui
@@ -29,7 +29,7 @@
         <locale language="English" country="UnitedStates"/>
        </property>
        <property name="currentIndex">
-        <number>0</number>
+        <number>1</number>
        </property>
        <widget class="QWidget" name="basic_tab">
         <property name="locale">
@@ -792,7 +792,7 @@ border-width: 1px;</string>
             <property name="topMargin">
              <number>15</number>
             </property>
-            <item row="2" column="0">
+            <item row="5" column="0">
              <widget class="QLabel" name="label_26">
               <property name="text">
                <string>Default DispVM:</string>
@@ -802,17 +802,17 @@ border-width: 1px;</string>
               </property>
              </widget>
             </item>
-            <item row="2" column="1">
+            <item row="5" column="1">
              <widget class="QComboBox" name="default_dispvm"/>
             </item>
-            <item row="3" column="0" colspan="2">
+            <item row="6" column="0" colspan="2">
              <widget class="QPushButton" name="boot_from_device_button">
               <property name="text">
                <string>Boot qube from CDROM</string>
               </property>
              </widget>
             </item>
-            <item row="4" column="0" colspan="2">
+            <item row="7" column="0" colspan="2">
              <layout class="QHBoxLayout" name="horizontalLayout_8">
               <item>
                <widget class="QPushButton" name="seamless_on_button">
@@ -838,7 +838,14 @@ The qube must be running to disable seamless mode; this setting is not persisten
               </item>
              </layout>
             </item>
-            <item row="1" column="0" colspan="2">
+            <item row="1" column="0">
+             <widget class="QCheckBox" name="provides_network_checkbox">
+              <property name="text">
+               <string>Provides network</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
              <widget class="QCheckBox" name="dvm_template_checkbox">
               <property name="toolTip">
                <string/>


### PR DESCRIPTION
A simple checkbox in the 'Advanced' tab. Does not allow disabling
'provides_network' if the VM is in use as NetVM; instead, a tooltip
informs the user which VMs use it.

fixes QubesOS/qubes-issues#5079