### PR TITLE
Reworded warning tooltip in settings

### DIFF
--- a/ui/settingsdlg.ui
+++ b/ui/settingsdlg.ui
@@ -396,7 +396,7 @@
             <item row="2" column="3">
              <widget class="QLabel" name="warn_netvm_dispvm">
               <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Caution: default DispVM template has a different Networking setting than this qube. Unexpected network access may occur!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Caution:&lt;/span&gt; The Default DisposableVM Template (see the Advanced tab) has a different Networking setting than this qube. This configuration may result in unexpected network access. For example, you may have set this qube's Networking to &amp;quot;none&amp;quot; in order to prevent any data from being transmitted out. However, if the Default DisposableVM Template's Networking is set to &amp;quot;sys-firewall,&amp;quot; then a DisposableVM started from this qube may be able to transmit data out, contrary to your intention. You may wish to set the Default DisposableVM Template for this qube to one with equally restrictive Networking settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="text">
                <string/>


### PR DESCRIPTION
Made the tooltip warning of unexpected network access more descriptive.

fixes QubesOS/qubes-issues#5115