### PR TITLE
Renamed DispVM and "Is DispVM template" for more readability

### DIFF
--- a/ui/globalsettingsdlg.ui
+++ b/ui/globalsettingsdlg.ui
@@ -88,7 +88,7 @@
       <item row="4" column="0">
        <widget class="QLabel" name="label_8">
         <property name="text">
-         <string>Default DispVM:</string>
+         <string>Default DisposableVM Template:</string>
         </property>
        </widget>
       </item>

--- a/ui/qubemanager.ui
+++ b/ui/qubemanager.ui
@@ -238,14 +238,14 @@ in backups</string>
       </column>
       <column>
        <property name="text">
-        <string>Default
-DisposableVM</string>
+        <string>Default DisposableVM
+Template</string>
        </property>
       </column>
       <column>
        <property name="text">
-        <string>Is template for 
-DisposableVMs</string>
+        <string>DisposableVM
+Template</string>
        </property>
       </column>
      </widget>
@@ -258,7 +258,7 @@ DisposableVMs</string>
      <x>0</x>
      <y>0</y>
      <width>1100</width>
-     <height>28</height>
+     <height>23</height>
     </rect>
    </property>
    <property name="contextMenuPolicy">
@@ -853,10 +853,10 @@ DisposableVMs</string>
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Default DisposableVMs</string>
+    <string>Default DisposableVM Template</string>
    </property>
    <property name="toolTip">
-    <string>Default DisposableVMs</string>
+    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Default DisposableVM Template&lt;br/&gt;&lt;br/&gt;Which qube should be used by default as a template for DisposableVMs started from this one? DisposableVMs will inherit their template's configuration and installed programs.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
    </property>
   </action>
   <action name="action_is_dvm_template">
@@ -867,10 +867,10 @@ DisposableVMs</string>
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Is Template for DisposableVMs</string>
+    <string>DisposableVM Template</string>
    </property>
    <property name="toolTip">
-    <string>Is Template for DisposableVMs</string>
+    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DisposableVM Template&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Allows using this qube as a template for DisposableVMs. The DisposableVMs will inherit the VM's state (configuration, installed programs etc.), but their state will not persist between restarts. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
    </property>
   </action>
  </widget>

--- a/ui/settingsdlg.ui
+++ b/ui/settingsdlg.ui
@@ -808,8 +808,11 @@ border-width: 1px;</string>
             </property>
             <item row="5" column="0">
              <widget class="QLabel" name="label_26">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Which qube should be used by default as a template for DisposableVMs started from this one? DisposableVMs will inherit their template's configuration and installed programs.&lt;br/&gt;For a qube to to appear in this list, it must have the &amp;quot;DisposableVM Template&amp;quot; checkbox enabled. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
               <property name="text">
-               <string>Default DispVM:</string>
+               <string>Default DisposableVM Template</string>
               </property>
               <property name="buddy">
                <cstring>default_dispvm</cstring>
@@ -817,7 +820,11 @@ border-width: 1px;</string>
              </widget>
             </item>
             <item row="5" column="1">
-             <widget class="QComboBox" name="default_dispvm"/>
+             <widget class="QComboBox" name="default_dispvm">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Which qube should be used by default as a template for DisposableVMs started from this one? DisposableVMs will inherit their template's configuration and installed programs.&lt;br/&gt;For a qube to to appear in this list, it must have the &amp;quot;DisposableVM Template&amp;quot; checkbox enabled. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+             </widget>
             </item>
             <item row="6" column="0" colspan="2">
              <widget class="QPushButton" name="boot_from_device_button">
@@ -862,10 +869,10 @@ The qube must be running to disable seamless mode; this setting is not persisten
             <item row="2" column="0">
              <widget class="QCheckBox" name="dvm_template_checkbox">
               <property name="toolTip">
-               <string/>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Allows using this qube as a template for DisposableVMs. The DisposableVMs will inherit the VM's state (configuration, installed programs etc.), but their state will not persist between restarts. &lt;/p&gt;&lt;p&gt;Setting this option will cause this qube to be listed as an option in the &amp;quot;Default DisposableVM Template&amp;quot; dropdown for all other qubes. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="text">
-               <string>Allow starting DisposableVMs from this qube</string>
+               <string>Disposable VM Template</string>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
Replaced instances of "Default DispVM" and "Is DVM Template" with
more readable "Default Disposable VM Template" and "Disposable VM Template"
respectively. Added tooltips.

fixes QubesOS/qubes-issues#4935