### PR TITLE
make else/default branch of version-detection non-fatal ...

### DIFF
--- a/qubesmanager/dsa-4371-update
+++ b/qubesmanager/dsa-4371-update
@@ -76,7 +76,7 @@ main() {
             fixed_version="1.4.9"
             ;;
         *)
-            error 'Error: Could not determine Debian release!'
+            exit_ok 'changed=no' 'Unrecognized debian variant, but probably ok by now'
     esac
 
     if check_apt_version "$pkg" "$fixed_version"; then


### PR DESCRIPTION
... since any new-and-coming debian variants at this point probably are 4371 fixed to begin with

for https://github.com/QubesOS/qubes-issues/issues/5150