### PR TITLE
Two fixes for Create New VM

### DIFF
--- a/qubesmanager/create_new_vm.py
+++ b/qubesmanager/create_new_vm.py
@@ -135,12 +135,10 @@ class NewVmDlg(QtGui.QDialog, Ui_NewVMDlg):
                    else 'StandaloneVM')
 
         name = str(self.name.text())
-        try:
-            self.app.domains[name]
-        except LookupError:
-            pass
-        else:
-            QtGui.QMessageBox.warning(None,
+
+        if name in self.app.domains:
+            QtGui.QMessageBox.warning(
+                None,
                 self.tr('Incorrect qube name!'),
                 self.tr('A qube with the name <b>{}</b> already exists in the '
                         'system!').format(name))

--- a/qubesmanager/create_new_vm.py
+++ b/qubesmanager/create_new_vm.py
@@ -153,9 +153,12 @@ class NewVmDlg(QtGui.QDialog, Ui_NewVMDlg):
 
         properties = {}
         properties['provides_network'] = self.provides_network.isChecked()
+
         if self.netvm.currentIndex() != 0:
             properties['netvm'] = self.netvm_list[self.netvm.currentIndex()]
-        if self.install_system.isChecked():
+
+        # Standalone - not based on a template
+        if self.vm_type.currentIndex() == 2:
             properties['virt_mode'] = 'hvm'
             properties['kernel'] = None
 


### PR DESCRIPTION
Minor pre-emptive fix for not-yet-existing "VM name lookup" issue
and a fix for incorrect defaults for standalone VMs not based on a
template
fixes QubesOS/qubes-issues#5203