### PR TITLE
Better handling of port/service names for VM settings

### DIFF
--- a/qubesmanager/firewall.py
+++ b/qubesmanager/firewall.py
@@ -109,7 +109,7 @@ class NewFwRuleDlg(QtGui.QDialog, ui_newfwruledlg.Ui_NewFwRuleDlg):
                 'http', 'https', 'ftp', 'ftps', 'smtp',
                 'pop3', 'pop3s', 'imap', 'imaps', 'odmr',
                 'nntp', 'nntps', 'ssh', 'telnet', 'telnets', 'ntp',
-                'snmp', 'ldap', 'ldaps', 'irc', 'ircs', 'xmpp-client',
+                'snmp', 'ldap', 'ldaps', 'irc', 'ircs-u', 'xmpp-client',
                 'syslog', 'printer', 'nfs', 'x11'
             ]
         for address in example_addresses:
@@ -144,6 +144,9 @@ class QubesFirewallRulesModel(QtCore.QAbstractItemModel):
 
         self.__column_names = {0: "Address", 1: "Port/Service", 2: "Protocol", }
         self.__services = list()
+
+        self.port_range_pattern = re.compile(r'\d+-\d+')
+
         pattern = re.compile(
             r"(?P<name>[a-z][a-z0-9-]+)\s+(?P<port>[0-9]+)/"
             r"(?P<protocol>[a-z]+)",
@@ -380,7 +383,7 @@ class QubesFirewallRulesModel(QtCore.QAbstractItemModel):
             elif dialog.udp_radio.isChecked():
                 rule.proto = 'udp'
 
-            if '-' in service:
+            if self.port_range_pattern.fullmatch(service):
                 try:
                     rule.dstports = service
                 except ValueError:

--- a/qubesmanager/firewall.py
+++ b/qubesmanager/firewall.py
@@ -104,18 +104,17 @@ class NewFwRuleDlg(QtGui.QDialog, ui_newfwruledlg.Ui_NewFwRuleDlg):
                 "192.168.1.100", "192.168.0.0/16",
                 "*"
             ]
-        displayed_services = [
-                '',
+        example_services = [
+                '', '22', '80', '1024-1234',
                 'http', 'https', 'ftp', 'ftps', 'smtp',
-                'smtps', 'pop3', 'pop3s', 'imap', 'imaps', 'odmr',
+                'pop3', 'pop3s', 'imap', 'imaps', 'odmr',
                 'nntp', 'nntps', 'ssh', 'telnet', 'telnets', 'ntp',
                 'snmp', 'ldap', 'ldaps', 'irc', 'ircs', 'xmpp-client',
-                'syslog', 'printer', 'nfs', 'x11',
-                '1024-1234'
+                'syslog', 'printer', 'nfs', 'x11'
             ]
         for address in example_addresses:
             self.addressComboBox.addItem(address)
-        for service in displayed_services:
+        for service in example_services:
             self.serviceComboBox.addItem(service)
 
     def address_editing_finished(self):
@@ -143,7 +142,7 @@ class QubesFirewallRulesModel(QtCore.QAbstractItemModel):
     def __init__(self, parent=None):
         QtCore.QAbstractItemModel.__init__(self, parent)
 
-        self.__column_names = {0: "Address", 1: "Service", 2: "Protocol", }
+        self.__column_names = {0: "Address", 1: "Port/Service", 2: "Protocol", }
         self.__services = list()
         pattern = re.compile(
             r"(?P<name>[a-z][a-z0-9-]+)\s+(?P<port>[0-9]+)/"
@@ -176,7 +175,7 @@ class QubesFirewallRulesModel(QtCore.QAbstractItemModel):
     def get_service_name(self, port):
         for service in self.__services:
             if str(service[1]) == str(port):
-                return service[0]
+                return "{0} ({1})".format(str(port), service[0])
         return str(port)
 
     def get_service_port(self, name):

--- a/ui/newfwruledlg.ui
+++ b/ui/newfwruledlg.ui
@@ -53,7 +53,7 @@
      <item row="1" column="0">
       <widget class="QLabel" name="label_4">
        <property name="text">
-        <string>Service</string>
+        <string>Port/Service</string>
        </property>
       </widget>
      </item>
@@ -98,6 +98,9 @@
      </item>
      <item row="1" column="1" colspan="3">
       <widget class="QComboBox" name="serviceComboBox">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Port/service can be provided as either port number (e.g. 122), port range (1024-1234) or service name (e.g. smtp) . For full list of services known, see /etc/services in dom0.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
        <property name="editable">
         <bool>true</bool>
        </property>


### PR DESCRIPTION
Now port will be displayed as port_number [(service name)]
, and not just service name. Also added a tooltip with explanation
of what can be put in the 'port/service' field, renamed
the field to 'Port/service' and added some examples of pure port
numbers to the drop down.
Also removed 'smtps' from the list of services because it was not in 
/etc/services and fixed parsing of port ranges.

fixes QubesOS/qubes-issues#5211
fixes QubesOS/qubes-issues#4766