### PR TITLE
Fix arithmetic in init/max mem ratio correction

### DIFF
--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -551,7 +551,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtGui.QDialog):
                 self.tr("Initial memory can not be less than one tenth "
                         "Max memory.<br>Setting initial memory to the minimum "
                         "allowed value."))
-            self.init_mem.setValue(self.max_mem_size.value() / 10)
+            self.init_mem.setValue((self.max_mem_size.value() + 9) // 10)
 
     def check_warn_dispvmnetvm(self):
         if not hasattr(self.vm, 'default_dispvm'):


### PR DESCRIPTION
From the commit message:

> Qubes Manager seems to try to guarantee that 10\*init_mem is at
> least max_mem by automatically adjusting init_mem to max_mem/10 if
> inappropriate values are set. However, this may not guarantee that
> 10\*init_mem >= max_mem due to rounding errors. This change fixes
> these edge cases by basically rounding up the result of division
> by 10.

Background: I discovered the issue that this change is trying to fix when I had an unround `max_mem` value like 4096 and a too low `init_mem` value which was (probably) automatically set to another inadmissible value, ending up in an infinite loop of warning windows. In retrospective, I'm a bit puzzled because this shouldn't be a problem in that range as `/` is floating point division in Python 3, but I still think that it's better to (use integer division and) round up because for values that are large enough even floating point arithmetic becomes too imprecise.