### PR TITLE
Fixed UI error

### DIFF
--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -484,6 +484,8 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtWidgets.QMainWindow):
 
         self.fill_table()
 
+        self.table.resizeColumnsToContents()
+
         self.update_size_on_disk = False
         self.shutdown_monitor = {}
 


### PR DESCRIPTION
Qube Manager columns did not resize correctly in Qt5.

fixes QubesOS/qubes-issues#5278