### PR TITLE
Show the previous VM name while renaming

### DIFF
--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -594,7 +594,8 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
         new_vm_name, ok = QtWidgets.QInputDialog.getText(
             self,
             self.tr('Rename qube'),
-            self.tr('New name: (WARNING: all other changes will be discarded)'))
+            self.tr('New name: (WARNING: all other changes will be discarded)'),
+            text=self.vm.name)
 
         if ok:
             thread = RenameVMThread(self.vm, new_vm_name, dependencies)


### PR DESCRIPTION
Currently while renaming VMs, the default text is empty "". This change modifies this default text to the original name of the VM.

This makes it a lot easier to make small changes to the name. The original name is also _selected_ by default, so replacing it entirely is also easily -- simply start typing the new name.