### PR TITLE
Fixed incorrect QApplication start that led to missing icons

### DIFF
--- a/qubesmanager/backup.py
+++ b/qubesmanager/backup.py
@@ -25,7 +25,7 @@ from qubesadmin import exc
 from qubesadmin import utils as admin_utils
 from qubes.storage.file import get_disk_usage
 
-from PyQt5 import QtCore, QtWidgets, QtGui  # pylint: disable=import-error
+from PyQt5 import QtCore, QtWidgets  # pylint: disable=import-error
 from . import ui_backupdlg  # pylint: disable=no-name-in-module
 from . import multiselectwidget
 
@@ -386,7 +386,7 @@ class BackupVMsWindow(ui_backupdlg.Ui_Backup, QtWidgets.QWizard):
 
 def main():
     utils.run_asynchronous("Qubes Backup VMs",
-                           QtGui.QIcon.fromTheme("qubes-manager"),
+                           "qubes-manager",
                            BackupVMsWindow)
 
 

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -1301,7 +1301,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QtWidgets.QMainWindow):
 def main():
     manager_utils.run_asynchronous(
         "Qube Manager",
-        QtGui.QIcon.fromTheme("qubes-manager"),
+        "qubes-manager",
         VmManagerWindow)
 
 

--- a/qubesmanager/template_manager.py
+++ b/qubesmanager/template_manager.py
@@ -379,7 +379,7 @@ class VMRow:
 
 def main():
     utils.run_asynchronous("Template Manager",
-                           QtGui.QIcon.fromTheme("qubes-manager"),
+                           "qubes-manager",
                            TemplateManagerWindow)
 
 

--- a/qubesmanager/utils.py
+++ b/qubesmanager/utils.py
@@ -262,12 +262,12 @@ def handle_exception(exc_type, exc_value, exc_traceback):
     msg_box.exec_()
 
 
-def run_asynchronous(app_name, icon, window_class):
+def run_asynchronous(app_name, icon_name, window_class):
     qt_app = QtWidgets.QApplication(sys.argv)
     qt_app.setOrganizationName("The Qubes Project")
     qt_app.setOrganizationDomain("http://qubes-os.org")
     qt_app.setApplicationName(app_name)
-    qt_app.setWindowIcon(icon)
+    qt_app.setWindowIcon(QIcon.fromTheme(icon_name))
     qt_app.lastWindowClosed.connect(loop_shutdown)
 
     qubes_app = qubesadmin.Qubes()


### PR DESCRIPTION
Using QIcon object before initializing QApplication leads to
missing theme icons.

fixes QubesOS/qubes-issues#5354