### PR TITLE
Manager tests fixed for Qt5

### DIFF
--- a/qubesmanager/backup.py
+++ b/qubesmanager/backup.py
@@ -357,9 +357,15 @@ class BackupVMsWindow(ui_backupdlg.Ui_Backup, QtWidgets.QWizard):
     def reject(self):
         if (self.currentPage() is self.commit_page) and \
                 self.button(self.CancelButton).isEnabled():
-            self.qubes_app.qubesd_call(
-                'dom0', 'admin.backup.Cancel',
-                backup_utils.get_profile_name(True))
+            try:
+                self.qubes_app.qubesd_call(
+                    'dom0', 'admin.backup.Cancel',
+                    backup_utils.get_profile_name(True))
+            except exc.QubesException as ex:
+                QtWidgets.QMessageBox.warning(
+                    self, self.tr("Error cancelling backup!"),
+                    self.tr("ERROR: {}").format(str(ex)))
+
             self.thread.wait()
             QtWidgets.QMessageBox.warning(
                 self, self.tr("Backup aborted!"),

--- a/qubesmanager/global_settings.py
+++ b/qubesmanager/global_settings.py
@@ -20,8 +20,6 @@
 #
 #
 
-import os
-import os.path
 import subprocess
 from PyQt5 import QtWidgets  # pylint: disable=import-error
 
@@ -245,15 +243,11 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
                 qmemman_config_file.close()
 
     def __init_updates__(self):
-        # TODO: remove workaround when it is no longer needed
-        self.dom0_updates_file_path = '/var/lib/qubes/updates/disable-updates'
-
         try:
             self.updates_dom0_val = bool(self.qvm_collection.domains[
                 'dom0'].features['service.qubes-update-check'])
         except KeyError:
-            self.updates_dom0_val =\
-                not os.path.isfile(self.dom0_updates_file_path)
+            self.updates_dom0_val = True
 
         self.updates_dom0.setChecked(self.updates_dom0_val)
 

--- a/qubesmanager/tests/__init__.py
+++ b/qubesmanager/tests/__init__.py
@@ -1,0 +1,16 @@
+import asyncio
+import sys
+
+import quamash
+from PyQt5 import QtWidgets
+
+qtapp = None
+loop = None
+
+def init_qtapp():
+    global qtapp, loop
+    if qtapp is None:
+        qtapp = QtWidgets.QApplication(sys.argv)
+        loop = quamash.QEventLoop(qtapp)
+        asyncio.set_event_loop(loop)
+    return qtapp, loop

--- a/qubesmanager/tests/test_backup_utils.py
+++ b/qubesmanager/tests/test_backup_utils.py
@@ -21,29 +21,18 @@
 #
 import logging.handlers
 import unittest.mock
-import quamash
-import asyncio
-import sys
 from PyQt5 import QtWidgets
 from qubesadmin import Qubes
 
 from qubesmanager import backup_utils
-
-qtapp = QtWidgets.QApplication(sys.argv)
-loop = quamash.QEventLoop(qtapp)
-asyncio.set_event_loop(loop)
+from qubesmanager.tests import init_qtapp
 
 
 class BackupUtilsTest(unittest.TestCase):
     def setUp(self):
         super(BackupUtilsTest, self).setUp()
+        self.qtapp, self.loop = init_qtapp()
         self.qapp = Qubes()
-        self.loop = quamash.QEventLoop(qtapp)
-
-    def tearDown(self):
-        qtapp.processEvents()
-        yield from loop.sleep(1)
-        super(BackupUtilsTest, self).tearDown()
 
     def test_01_fill_apvms(self):
         dialog = QtWidgets.QDialog()

--- a/qubesmanager/tests/test_backup_utils.py
+++ b/qubesmanager/tests/test_backup_utils.py
@@ -23,48 +23,31 @@ import logging.handlers
 import unittest.mock
 import quamash
 import asyncio
-import gc
-from PyQt4 import QtGui
+import sys
+from PyQt5 import QtWidgets
 from qubesadmin import Qubes
 
 from qubesmanager import backup_utils
+
+qtapp = QtWidgets.QApplication(sys.argv)
+loop = quamash.QEventLoop(qtapp)
+asyncio.set_event_loop(loop)
 
 
 class BackupUtilsTest(unittest.TestCase):
     def setUp(self):
         super(BackupUtilsTest, self).setUp()
         self.qapp = Qubes()
-        self.qtapp = QtGui.QApplication(["test", "-style", "cleanlooks"])
-        self.loop = quamash.QEventLoop(self.qtapp)
+        self.loop = quamash.QEventLoop(qtapp)
 
     def tearDown(self):
-        # process any pending events before destroying the object
-        self.qtapp.processEvents()
-
-        # queue destroying the QApplication object, do that for any other QT
-        # related objects here too
-        self.qtapp.deleteLater()
-
-        # process any pending events (other than just queued destroy),
-        # just in case
-        self.qtapp.processEvents()
-
-        # execute main loop, which will process all events, _
-        # including just queued destroy_
-        self.loop.run_until_complete(asyncio.sleep(0))
-
-        # at this point it QT objects are destroyed, cleanup all remaining
-        # references;
-        # del other QT object here too
-        self.loop.close()
-        del self.qtapp
-        del self.loop
-        gc.collect()
+        qtapp.processEvents()
+        yield from loop.sleep(1)
         super(BackupUtilsTest, self).tearDown()
 
     def test_01_fill_apvms(self):
-        dialog = QtGui.QDialog()
-        combobox = QtGui.QComboBox()
+        dialog = QtWidgets.QDialog()
+        combobox = QtWidgets.QComboBox()
         dialog.appvm_combobox = combobox
         dialog.qubes_app = self.qapp
 
@@ -85,8 +68,6 @@ class BackupUtilsTest(unittest.TestCase):
 
         self.assertListEqual(sorted(expected_vm_list), sorted(received_vm_list),
                              "VM list not filled correctly")
-
-
 
 
 if __name__ == "__main__":

--- a/qubesmanager/tests/test_create_new_vm.py
+++ b/qubesmanager/tests/test_create_new_vm.py
@@ -51,12 +51,6 @@ class NewVmTest(unittest.TestCase):
 
         self.dialog = create_new_vm.NewVmDlg(self.qtapp, self.qapp)
 
-    def tearDown(self):
-        self.dialog.close()
-        self.qtapp.processEvents()
-        yield from self.loop.sleep(1)
-        super(NewVmTest, self).tearDown()
-
     def test_00_window_loads(self):
         self.assertGreater(self.dialog.template_vm.count(), 0,
                            "No templates shown")
@@ -68,13 +62,13 @@ class NewVmTest(unittest.TestCase):
                          "Attempted to create VM on cancel")
 
     def test_02_create_simple_vm(self):
-        self.dialog.name.setText("testvm")
+        self.dialog.name.setText("test-vm")
         self.__click_ok()
 
         self.mock_thread.assert_called_once_with(
-            self.qapp, "AppVM", "testvm",
+            self.qapp, "AppVM", "test-vm",
             unittest.mock.ANY, qubesadmin.DEFAULT,
-            {'provides_network': False})
+            {'provides_network': False}, unittest.mock.ANY)
         self.mock_thread().start.assert_called_once_with()
 
     def test_03_label(self):
@@ -83,13 +77,13 @@ class NewVmTest(unittest.TestCase):
                 self.dialog.label.setCurrentIndex(i)
                 break
 
-        self.dialog.name.setText("testvm")
+        self.dialog.name.setText("test-vm")
         self.__click_ok()
 
         self.mock_thread.assert_called_once_with(
-            self.qapp, "AppVM", "testvm",
+            self.qapp, "AppVM", "test-vm",
             self.qapp.labels['blue'], qubesadmin.DEFAULT,
-            unittest.mock.ANY)
+            unittest.mock.ANY, unittest.mock.ANY)
         self.mock_thread().start.assert_called_once_with()
 
     def test_04_template(self):
@@ -100,13 +94,13 @@ class NewVmTest(unittest.TestCase):
                 template = self.dialog.template_vm.currentText()
                 break
 
-        self.dialog.name.setText("testvm")
+        self.dialog.name.setText("test-vm")
         self.__click_ok()
 
         self.mock_thread.assert_called_once_with(
-            self.qapp, "AppVM", "testvm",
+            self.qapp, "AppVM", "test-vm",
             unittest.mock.ANY, template,
-            unittest.mock.ANY)
+            unittest.mock.ANY, unittest.mock.ANY)
 
     def test_05_netvm(self):
         netvm = None
@@ -116,53 +110,53 @@ class NewVmTest(unittest.TestCase):
                 netvm = self.dialog.netvm.currentText()
                 break
 
-        self.dialog.name.setText("testvm")
+        self.dialog.name.setText("test-vm")
         self.__click_ok()
 
         self.mock_thread.assert_called_once_with(
-            self.qapp, "AppVM", "testvm",
+            self.qapp, "AppVM", "test-vm",
             unittest.mock.ANY, unittest.mock.ANY,
-            {'netvm': netvm, 'provides_network': False})
+            {'netvm': netvm, 'provides_network': False}, unittest.mock.ANY)
 
     def test_06_provides_network(self):
         self.dialog.provides_network.setChecked(True)
 
-        self.dialog.name.setText("testvm")
+        self.dialog.name.setText("test-vm")
         self.__click_ok()
 
         self.mock_thread.assert_called_once_with(
-            self.qapp, "AppVM", "testvm",
+            self.qapp, "AppVM", "test-vm",
             unittest.mock.ANY, unittest.mock.ANY,
-            {'provides_network': True})
+            {'provides_network': True}, unittest.mock.ANY)
 
     @unittest.mock.patch('subprocess.check_call')
     def test_07_launch_settings(self, mock_call):
         self.dialog.launch_settings.setChecked(True)
 
-        self.dialog.name.setText("testvm")
+        self.dialog.name.setText("test-vm")
 
         self.__click_ok()
 
         # make sure the thread is not reporting an error
         self.mock_thread.assert_called_once_with(
-            self.qapp, "AppVM", "testvm",
+            self.qapp, "AppVM", "test-vm",
             unittest.mock.ANY, unittest.mock.ANY,
-            unittest.mock.ANY)
+            unittest.mock.ANY, unittest.mock.ANY)
 
         self.mock_thread().msg = None
         self.dialog.create_finished()
 
-        mock_call.assert_called_once_with(['qubes-vm-settings', "testvm"])
+        mock_call.assert_called_once_with(['qubes-vm-settings', "test-vm"])
 
     def test_08_progress_hides(self):
-        self.dialog.name.setText("testvm")
+        self.dialog.name.setText("test-vm")
 
         self.__click_ok()
 
         self.mock_thread.assert_called_once_with(
-            self.qapp, "AppVM", "testvm",
+            self.qapp, "AppVM", "test-vm",
             unittest.mock.ANY, unittest.mock.ANY,
-            unittest.mock.ANY)
+            unittest.mock.ANY, unittest.mock.ANY)
 
         # make sure the thread is not reporting an error
         self.mock_thread().start.assert_called_once_with()
@@ -175,7 +169,7 @@ class NewVmTest(unittest.TestCase):
         self.mock_progress().hide.assert_called_once_with()
 
     def test_09_standalone_clone(self):
-        self.dialog.name.setText("testvm")
+        self.dialog.name.setText("test-vm")
         for i in range(self.dialog.vm_type.count()):
             opt_text = self.dialog.vm_type.itemText(i).lower()
             if "standalone" in opt_text and "template" in opt_text and\
@@ -185,13 +179,13 @@ class NewVmTest(unittest.TestCase):
 
         self.__click_ok()
         self.mock_thread.assert_called_once_with(
-            self.qapp, "StandaloneVM", "testvm",
+            self.qapp, "StandaloneVM", "test-vm",
             unittest.mock.ANY, unittest.mock.ANY,
-            unittest.mock.ANY)
+            unittest.mock.ANY, unittest.mock.ANY)
 
     @unittest.mock.patch('subprocess.check_call')
     def test_10_standalone_empty(self, mock_call):
-        self.dialog.name.setText("testvm")
+        self.dialog.name.setText("test-vm")
         for i in range(self.dialog.vm_type.count()):
             opt_text = self.dialog.vm_type.itemText(i).lower()
             if "standalone" in opt_text and\
@@ -201,19 +195,19 @@ class NewVmTest(unittest.TestCase):
 
         self.__click_ok()
         self.mock_thread.assert_called_once_with(
-            self.qapp, "StandaloneVM", "testvm",
+            self.qapp, "StandaloneVM", "test-vm",
             unittest.mock.ANY, None,
-            unittest.mock.ANY)
+            unittest.mock.ANY, unittest.mock.ANY)
 
         self.mock_thread().msg = None
         self.dialog.create_finished()
 
         mock_call.assert_called_once_with(['qubes-vm-boot-from-device',
-                                           'testvm'])
+                                           'test-vm'])
 
     @unittest.mock.patch('subprocess.check_call')
     def test_11_standalone_empty_not_install(self, mock_call):
-        self.dialog.name.setText("testvm")
+        self.dialog.name.setText("test-vm")
 
         for i in range(self.dialog.vm_type.count()):
             opt_text = self.dialog.vm_type.itemText(i).lower()
@@ -226,9 +220,9 @@ class NewVmTest(unittest.TestCase):
 
         self.__click_ok()
         self.mock_thread.assert_called_once_with(
-            self.qapp, "StandaloneVM", "testvm",
+            self.qapp, "StandaloneVM", "test-vm",
             unittest.mock.ANY, None,
-            unittest.mock.ANY)
+            unittest.mock.ANY, unittest.mock.ANY)
 
         self.mock_thread().msg = None
         self.dialog.create_finished()

--- a/qubesmanager/tests/test_global_settings.py
+++ b/qubesmanager/tests/test_global_settings.py
@@ -128,8 +128,7 @@ class GlobalSettingsTest(unittest.TestCase):
             dom0_updates = self.qapp.domains[
                 'dom0'].features['service.qubes-update-check']
         except KeyError:
-            self.skipTest("check_updates_dom0 property not implemented")
-            return
+            dom0_updates = True
 
         self.assertEqual(bool(dom0_updates),
                          self.dialog.updates_dom0.isChecked(),

--- a/qubesmanager/tests/test_global_settings.py
+++ b/qubesmanager/tests/test_global_settings.py
@@ -43,12 +43,6 @@ class GlobalSettingsTest(unittest.TestCase):
         self.setattr_mock = self.setattr_patcher.start()
         self.addCleanup(self.setattr_patcher.stop)
 
-    def tearDown(self):
-        self.dialog.close()
-        self.qtapp.processEvents()
-        yield from self.loop.sleep(1)
-        super(GlobalSettingsTest, self).tearDown()
-
     def test_00_settings_started(self):
         # non-empty drop-downs
         self.assertNotEqual(

--- a/qubesmanager/tests/test_vm_settings.py
+++ b/qubesmanager/tests/test_vm_settings.py
@@ -23,10 +23,7 @@ import logging.handlers
 import unittest
 import unittest.mock
 
-import gc
-import asyncio
-
-from PyQt5 import QtTest, QtCore, QtWidgets
+from PyQt5 import QtTest, QtCore
 from qubesadmin import Qubes
 import qubesmanager.settings as vm_settings
 from qubesmanager.tests import init_qtapp
@@ -44,64 +41,63 @@ class VMSettingsTest(unittest.TestCase):
         self.addCleanup(self.mock_qprogress.stop)
 
         self.qapp = Qubes()
-        
-        if "testvm" in self.qapp.domains:
-            del self.qapp.domains["testvm"]
+
+        if "test-vm" in self.qapp.domains:
+            del self.qapp.domains["test-vm"]
 
     def tearDown(self):
-        del self.qapp.domains["testvm"]
-        self.qtapp.processEvents()
-        yield from self.loop.sleep(1)
-
+        if "test-vm" in self.qapp.domains:
+            del self.qapp.domains["test-vm"]
         super(VMSettingsTest, self).tearDown()
 
     def test_00_load_correct_tab(self):
-        self.vm = self.qapp.add_new_vm("AppVM", "testvm", "red")
+        self.vm = self.qapp.add_new_vm("AppVM", "test-vm", "red")
 
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "basic")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="basic")
         self.assertTrue(
             self.dialog.tabWidget.currentWidget() is self.dialog.basic_tab)
         self.dialog.deleteLater()
 
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "advanced")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="advanced")
         self.assertTrue(
             self.dialog.tabWidget.currentWidget() is self.dialog.advanced_tab)
         self.dialog.deleteLater()
 
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "firewall")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="firewall")
         self.assertTrue(
             self.dialog.tabWidget.currentWidget() is self.dialog.firewall_tab)
         self.dialog.deleteLater()
 
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "devices")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="devices")
         self.assertTrue(
             self.dialog.tabWidget.currentWidget() is self.dialog.devices_tab)
         self.dialog.deleteLater()
 
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "applications")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp,
+            init_page="applications")
         self.assertTrue(
             self.dialog.tabWidget.currentWidget() is self.dialog.apps_tab)
         self.dialog.deleteLater()
 
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "services")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="services")
         self.assertTrue(
             self.dialog.tabWidget.currentWidget() is self.dialog.services_tab)
         self.dialog.deleteLater()
 
     def test_01_basic_tab_default(self):
-        self.vm = self.qapp.add_new_vm("AppVM", "testvm", "blue")
+        self.vm = self.qapp.add_new_vm("AppVM", "test-vm", "blue")
         # set the vm to have a default template and netvm
 
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "basic")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="basic")
 
-        self.assertEqual(self.dialog.vmname.text(), "testvm",
+        self.assertEqual(self.dialog.vmname.text(), "test-vm",
                          "Name displayed incorrectly")
 
         self.assertTrue("blue" in self.dialog.vmlabel.currentText(),
@@ -156,12 +152,12 @@ class VMSettingsTest(unittest.TestCase):
                          "Incorrect max private root size")
 
     def test_02_basic_tab_nones(self):
-        self.vm = self.qapp.add_new_vm("StandaloneVM", "testvm", "blue")
+        self.vm = self.qapp.add_new_vm("StandaloneVM", "test-vm", "blue")
         # set the vm to have a default template and netvm
         self.vm.netvm = None
 
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "basic")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="basic")
 
         self.assertEqual("", self.dialog.template_name.currentText(),
                          "No template incorrectly displayed")
@@ -185,12 +181,11 @@ class VMSettingsTest(unittest.TestCase):
                          "---",
                          "Incorrect gateway displayed")
 
-    @unittest.expectedFailure
     def test_03_change_label(self):
-        # this test fails due to error where we check whether label is visible
-        self.vm = self.qapp.add_new_vm("AppVM", "testvm", "blue")
+        self.vm = self.qapp.add_new_vm("AppVM", "test-vm", "blue")
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "basic")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="basic")
+        self.dialog.show()
 
         new_label = self._set_noncurrent(self.dialog.vmlabel)
         self._click_ok()
@@ -199,9 +194,9 @@ class VMSettingsTest(unittest.TestCase):
                          "Label is not set correctly")
 
     def test_04_change_template(self):
-        self.vm = self.qapp.add_new_vm("AppVM", "testvm", "blue")
+        self.vm = self.qapp.add_new_vm("AppVM", "test-vm", "blue")
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "basic")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="basic")
 
         new_template = self._set_noncurrent(self.dialog.template_name)
         self._click_ok()
@@ -210,9 +205,9 @@ class VMSettingsTest(unittest.TestCase):
                          "Template is not set correctly")
 
     def test_05_change_networking(self):
-        self.vm = self.qapp.add_new_vm("AppVM", "testvm", "blue")
+        self.vm = self.qapp.add_new_vm("AppVM", "test-vm", "blue")
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "basic")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="basic")
 
         new_netvm = self._set_noncurrent(self.dialog.netVM)
         self._click_ok()
@@ -221,9 +216,9 @@ class VMSettingsTest(unittest.TestCase):
                          "NetVM is not set correctly")
 
     def test_06_change_networking_none(self):
-        self.vm = self.qapp.add_new_vm("AppVM", "testvm", "blue")
+        self.vm = self.qapp.add_new_vm("AppVM", "test-vm", "blue")
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "basic")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="basic")
 
         self._set_none(self.dialog.netVM)
         self._click_ok()
@@ -232,7 +227,7 @@ class VMSettingsTest(unittest.TestCase):
                           "None netVM is not set correctly")
 
     def test_07_change_networking_to_default(self):
-        self.vm = self.qapp.add_new_vm("AppVM", "testvm", "blue")
+        self.vm = self.qapp.add_new_vm("AppVM", "test-vm", "blue")
 
         for vm in self.qapp.domains:
             if getattr(vm, 'provides_network', False)\
@@ -241,7 +236,7 @@ class VMSettingsTest(unittest.TestCase):
                 break
 
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "basic")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="basic")
 
         new_netvm = self._set_default(self.dialog.netVM)
         self._click_ok()
@@ -250,11 +245,11 @@ class VMSettingsTest(unittest.TestCase):
                         "NetVM is not set correctly")
         self.assertTrue(self.vm.property_is_default('netvm'))
 
-    @unittest.expectedFailure
     def test_08_basic_checkboxes_true(self):
-        self.vm = self.qapp.add_new_vm("AppVM", "testvm", "blue")
+        self.vm = self.qapp.add_new_vm("AppVM", "test-vm", "blue")
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "basic")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="basic")
+        self.dialog.show()
 
         self.dialog.include_in_backups.setChecked(True)
         self.dialog.autostart_vm.setChecked(True)
@@ -269,11 +264,11 @@ class VMSettingsTest(unittest.TestCase):
         self.assertTrue(self.vm.debug,
                         "Debug mode not set to true")
 
-    @unittest.expectedFailure
     def test_09_basic_checkboxes_false(self):
-        self.vm = self.qapp.add_new_vm("AppVM", "testvm", "blue")
+        self.vm = self.qapp.add_new_vm("AppVM", "test-vm", "blue")
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "basic")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="basic")
+        self.dialog.show()
 
         self.dialog.include_in_backups.setChecked(False)
         self.dialog.autostart_vm.setChecked(False)
@@ -289,9 +284,9 @@ class VMSettingsTest(unittest.TestCase):
                          "Debug mode not set to false")
 
     def test_10_increase_private_storage(self):
-        self.vm = self.qapp.add_new_vm("AppVM", "testvm", "blue")
+        self.vm = self.qapp.add_new_vm("AppVM", "test-vm", "blue")
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "basic")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="basic")
 
         current_storage = self.vm.volumes['private'].size // 1024**2
         new_storage = current_storage + 512
@@ -308,16 +303,16 @@ class VMSettingsTest(unittest.TestCase):
     @unittest.mock.patch('PyQt5.QtWidgets.QInputDialog.getText')
     @unittest.mock.patch('qubesmanager.settings.RenameVMThread')
     def test_11_rename_vm(self, mock_thread, mock_input, _):
-        self.vm = self.qapp.add_new_vm("AppVM", "testvm", "blue")
+        self.vm = self.qapp.add_new_vm("AppVM", "test-vm", "blue")
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "basic")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="basic")
 
         self.assertTrue(self.dialog.rename_vm_button.isEnabled())
 
-        mock_input.return_value = ("testvm2", True)
+        mock_input.return_value = ("test-vm2", True)
         self.dialog.rename_vm_button.click()
 
-        mock_thread.assert_called_with(self.vm, "testvm2", unittest.mock.ANY)
+        mock_thread.assert_called_with(self.vm, "test-vm2", unittest.mock.ANY)
         mock_thread().start.assert_called_with()
 
 # TODO: thread tests for rename
@@ -326,16 +321,16 @@ class VMSettingsTest(unittest.TestCase):
     @unittest.mock.patch('PyQt5.QtWidgets.QInputDialog.getText')
     @unittest.mock.patch('qubesmanager.common_threads.CloneVMThread')
     def test_12_clone_vm(self, mock_thread, mock_input, _):
-        self.vm = self.qapp.add_new_vm("AppVM", "testvm", "blue")
+        self.vm = self.qapp.add_new_vm("AppVM", "test-vm", "blue")
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "basic")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="basic")
 
         self.assertTrue(self.dialog.clone_vm_button.isEnabled())
 
-        mock_input.return_value = ("testvm2", True)
+        mock_input.return_value = ("test-vm2", True)
         self.dialog.clone_vm_button.click()
 
-        mock_thread.assert_called_with(self.vm, "testvm2")
+        mock_thread.assert_called_with(self.vm, "test-vm2")
         mock_thread().start.assert_called_with()
 
     @unittest.mock.patch('PyQt5.QtWidgets.QMessageBox.warning')
@@ -343,19 +338,19 @@ class VMSettingsTest(unittest.TestCase):
     @unittest.mock.patch('PyQt5.QtWidgets.QInputDialog.getText')
     @unittest.mock.patch('qubesmanager.common_threads.RemoveVMThread')
     def test_13_remove_vm(self, mock_thread, mock_input, _, mock_warning):
-        self.vm = self.qapp.add_new_vm("AppVM", "testvm", "blue")
+        self.vm = self.qapp.add_new_vm("AppVM", "test-vm", "blue")
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "basic")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="basic")
 
         self.assertTrue(self.dialog.delete_vm_button.isEnabled())
 
         # try with a wrong name
-        mock_input.return_value = ("testvm2", True)
+        mock_input.return_value = ("test-vm2", True)
         self.dialog.delete_vm_button.click()
         self.assertEqual(mock_warning.call_count, 1)
 
         # and now correct one
-        mock_input.return_value = ("testvm", True)
+        mock_input.return_value = ("test-vm", True)
         self.dialog.delete_vm_button.click()
 
         mock_thread.assert_called_with(self.vm)
@@ -363,9 +358,9 @@ class VMSettingsTest(unittest.TestCase):
 
 # Advanced Tab
     def test_20_advanced_loads(self):
-        self.vm = self.qapp.add_new_vm("AppVM", "testvm", "blue")
+        self.vm = self.qapp.add_new_vm("AppVM", "test-vm", "blue")
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "advanced")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="advanced")
 
         self.assertEqual(self.dialog.init_mem.value(), self.vm.memory,
                          "Incorrect initial memory")
@@ -396,11 +391,11 @@ class VMSettingsTest(unittest.TestCase):
         self.assertTrue("PVH" in self.dialog.virt_mode.currentText())
 
     def test_21_nondefaultmaxmem(self):
-        self.vm = self.qapp.add_new_vm("AppVM", "testvm", "blue")
+        self.vm = self.qapp.add_new_vm("AppVM", "test-vm", "blue")
         self.vm.maxmem = 5000
 
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "advanced")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="advanced")
 
         self.assertEqual(self.dialog.max_mem_size.value(), 5000)
 
@@ -412,7 +407,7 @@ class VMSettingsTest(unittest.TestCase):
         self.dialog.deleteLater()
 
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "advanced")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="advanced")
         self.assertFalse(self.dialog.include_in_balancing.isChecked())
 
         self.dialog.include_in_balancing.setChecked(True)
@@ -422,11 +417,11 @@ class VMSettingsTest(unittest.TestCase):
         self.assertEqual(self.vm.maxmem, 5000)
 
     def test_22_initmem(self):
-        self.vm = self.qapp.add_new_vm("AppVM", "testvm", "blue")
+        self.vm = self.qapp.add_new_vm("AppVM", "test-vm", "blue")
         self.vm.memory = 500
 
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "advanced")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="advanced")
 
         self.assertEqual(self.dialog.init_mem.value(), 500,
                          "Incorrect initial memory")
@@ -436,11 +431,11 @@ class VMSettingsTest(unittest.TestCase):
         self.assertEqual(self.vm.memory, 600, "Setting initial memory failed")
 
     def test_23_vcpus(self):
-        self.vm = self.qapp.add_new_vm("AppVM", "testvm", "blue")
+        self.vm = self.qapp.add_new_vm("AppVM", "test-vm", "blue")
         self.vm.vcpus = 1
 
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "advanced")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="advanced")
         self.assertEqual(self.dialog.vcpus.value(), 1,
                          "Incorrect number of VCPUs")
 
@@ -451,9 +446,10 @@ class VMSettingsTest(unittest.TestCase):
                          "Incorrect number of VCPUs")
 
     def test_24_kernel(self):
-        self.vm = self.qapp.add_new_vm("AppVM", "testvm", "blue")
+        self.vm = self.qapp.add_new_vm("AppVM", "test-vm", "blue")
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "advanced")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="advanced")
+        self.dialog.show()
 
         new_kernel = self._set_noncurrent(self.dialog.kernel)
         self._click_ok()
@@ -463,20 +459,22 @@ class VMSettingsTest(unittest.TestCase):
         self.dialog.deleteLater()
 
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "advanced")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="advanced")
+        self.dialog.show()
         self._set_default(self.dialog.kernel)
 
         self._click_ok()
         self.assertTrue(self.vm.property_is_default('kernel'))
 
     def test_25_virtmode_change(self):
-        self.vm = self.qapp.add_new_vm("AppVM", "testvm", "blue")
+        self.vm = self.qapp.add_new_vm("AppVM", "test-vm", "blue")
 
         modes = ["HVM", "PVH", "PV"]
 
         for mode in modes:
             self.dialog = vm_settings.VMSettingsWindow(
-                self.vm, self.qtapp, "advanced")
+                self.vm, qapp=self.qtapp, qubesapp=self.qapp,
+                init_page="advanced")
 
             self._set_value(self.dialog.virt_mode, mode)
             self._click_ok()
@@ -486,17 +484,17 @@ class VMSettingsTest(unittest.TestCase):
             self.dialog.deleteLater()
 
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "advanced")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="advanced")
         self._set_default(self.dialog.virt_mode)
         self._click_ok()
 
         self.assertTrue(self.vm.property_is_default('virt_mode'))
 
     def test_26_default_dispvm(self):
-        self.vm = self.qapp.add_new_vm("AppVM", "testvm", "blue")
+        self.vm = self.qapp.add_new_vm("AppVM", "test-vm", "blue")
 
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "advanced")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="advanced")
 
         new_dvm = self._set_noncurrent(self.dialog.default_dispvm)
         self._click_ok()
@@ -506,7 +504,7 @@ class VMSettingsTest(unittest.TestCase):
         self.dialog.deleteLater()
 
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "advanced")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="advanced")
         self._set_default(self.dialog.default_dispvm)
         self._click_ok()
 
@@ -514,13 +512,13 @@ class VMSettingsTest(unittest.TestCase):
 
     @unittest.mock.patch('subprocess.check_call')
     def test_27_boot_cdrom(self, mock_call):
-        self.vm = self.qapp.add_new_vm("AppVM", "testvm", "blue")
+        self.vm = self.qapp.add_new_vm("AppVM", "test-vm", "blue")
 
         self.dialog = vm_settings.VMSettingsWindow(
-            self.vm, self.qtapp, "advanced")
+            self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="advanced")
 
         self.dialog.boot_from_device_button.click()
-        mock_call.assert_called_with(['qubes-vm-boot-from-device', "testvm"])
+        mock_call.assert_called_with(['qubes-vm-boot-from-device', "test-vm"])
 
     def _click_ok(self):
         okwidget = self.dialog.buttonBox.button(

--- a/qubesmanager/tests/test_vm_settings.py
+++ b/qubesmanager/tests/test_vm_settings.py
@@ -58,24 +58,28 @@ class VMSettingsTest(unittest.TestCase):
         self.assertTrue(
             self.dialog.tabWidget.currentWidget() is self.dialog.basic_tab)
         self.dialog.deleteLater()
+        self.qtapp.processEvents()
 
         self.dialog = vm_settings.VMSettingsWindow(
             self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="advanced")
         self.assertTrue(
             self.dialog.tabWidget.currentWidget() is self.dialog.advanced_tab)
         self.dialog.deleteLater()
+        self.qtapp.processEvents()
 
         self.dialog = vm_settings.VMSettingsWindow(
             self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="firewall")
         self.assertTrue(
             self.dialog.tabWidget.currentWidget() is self.dialog.firewall_tab)
         self.dialog.deleteLater()
+        self.qtapp.processEvents()
 
         self.dialog = vm_settings.VMSettingsWindow(
             self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="devices")
         self.assertTrue(
             self.dialog.tabWidget.currentWidget() is self.dialog.devices_tab)
         self.dialog.deleteLater()
+        self.qtapp.processEvents()
 
         self.dialog = vm_settings.VMSettingsWindow(
             self.vm, qapp=self.qtapp, qubesapp=self.qapp,
@@ -83,12 +87,14 @@ class VMSettingsTest(unittest.TestCase):
         self.assertTrue(
             self.dialog.tabWidget.currentWidget() is self.dialog.apps_tab)
         self.dialog.deleteLater()
+        self.qtapp.processEvents()
 
         self.dialog = vm_settings.VMSettingsWindow(
             self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="services")
         self.assertTrue(
             self.dialog.tabWidget.currentWidget() is self.dialog.services_tab)
         self.dialog.deleteLater()
+        self.qtapp.processEvents()
 
     def test_01_basic_tab_default(self):
         self.vm = self.qapp.add_new_vm("AppVM", "test-vm", "blue")
@@ -405,6 +411,7 @@ class VMSettingsTest(unittest.TestCase):
         self.assertEqual(self.vm.maxmem, 0)
 
         self.dialog.deleteLater()
+        self.qtapp.processEvents()
 
         self.dialog = vm_settings.VMSettingsWindow(
             self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="advanced")
@@ -457,6 +464,7 @@ class VMSettingsTest(unittest.TestCase):
         self.assertEqual(self.vm.kernel, new_kernel)
 
         self.dialog.deleteLater()
+        self.qtapp.processEvents()
 
         self.dialog = vm_settings.VMSettingsWindow(
             self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="advanced")
@@ -482,6 +490,7 @@ class VMSettingsTest(unittest.TestCase):
             self.assertEqual(self.vm.virt_mode.upper(), mode)
 
             self.dialog.deleteLater()
+            self.qtapp.processEvents()
 
         self.dialog = vm_settings.VMSettingsWindow(
             self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="advanced")
@@ -502,6 +511,7 @@ class VMSettingsTest(unittest.TestCase):
         self.assertEqual(self.vm.default_dispvm.name, new_dvm)
 
         self.dialog.deleteLater()
+        self.qtapp.processEvents()
 
         self.dialog = vm_settings.VMSettingsWindow(
             self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="advanced")

--- a/ui/newappvmdlg.ui
+++ b/ui/newappvmdlg.ui
@@ -210,6 +210,9 @@
        </item>
        <item row="2" column="0" colspan="2">
         <widget class="QCheckBox" name="install_system">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
          <property name="text">
           <string>install system from device (also available from settings)</string>
          </property>


### PR DESCRIPTION
A bunch of fixes for Qt5, including some fixes for features introduced after the switch.
Also a minor fix for issue found by tests.
And a fix for unhandled exception in backup.reject method that caused segfault when the backup
tool was ran without registering additional exception handler.

fixes QubesOS/qubes-issues#5395

