### PR TITLE
Fix KernelVersion comparisons

### DIFF
--- a/qubesmanager/utils.py
+++ b/qubesmanager/utils.py
@@ -125,6 +125,10 @@ class KernelVersion:  # pylint: disable=too-few-public-methods
                 self.groups, other.groups):
             if self_content == other_content:
                 continue
+            if self_content is None:
+                return True
+            if other_content is None:
+                return False
             if self_content.isdigit() and other_content.isdigit():
                 return int(self_content) < int(other_content)
             return self_content < other_content


### PR DESCRIPTION
Having kernels with certain names, `qubes-vm-settings` always crashed:

In the `__lt__` function for the class `KernelVersions`, if
`self.groups != other.groups`, but `self.groups == other.groups[0:n]` or
`self.groups[0:n] == other.groups` for some n, then at some point, one of
the two pieces to be compared will be `None`, which resulted in an
Exception when calling `isdigit`.

This is fixed in this commit by checking whether one of the pieces to be compared is `None` and handling this as a special case.

The same fix should apply to both master and release4.0, but I only tested it on release4.0.