### PR TITLE
Add handling for backup in progress

### DIFF
--- a/qubesmanager/backup.py
+++ b/qubesmanager/backup.py
@@ -52,6 +52,9 @@ class BackupThread(QtCore.QThread):
             self.vm.app.qubesd_call(
                 'dom0', 'admin.backup.Execute',
                 backup_utils.get_profile_name(True))
+        except exc.BackupAlreadyRunningError:
+            msg.append("This backup is already in progress! Cancel it "
+                       "or wait until it finishes.")
         except Exception as ex:  # pylint: disable=broad-except
             msg.append(str(ex))
 

--- a/test-packages/qubesadmin/exc.py
+++ b/test-packages/qubesadmin/exc.py
@@ -16,3 +16,7 @@ class QubesDaemonNoResponseError(BaseException):
 
 class BackupCancelledError(BaseException):
     pass
+
+
+class BackupAlreadyRunningError(BaseException):
+    pass


### PR DESCRIPTION
Shows a better error message when a given backup is already running.

fixes QubesOS/qubes-issues#5432
requires https://github.com/QubesOS/qubes-core-admin/pull/292