### PR TITLE
tests: fix startup timeout and looking for logs

### DIFF
--- a/qubesmanager/tests/test_qube_manager.py
+++ b/qubesmanager/tests/test_qube_manager.py
@@ -1084,9 +1084,9 @@ class QubeManagerTest(unittest.TestCase):
 
         self.addCleanup(
             subprocess.call,
-            ["qvm-shutdown", target_vm_name])
+            ["qvm-shutdown", "--wait", target_vm_name])
         self._run_command_and_process_events(
-            ["qvm-start", target_vm_name], timeout=20)
+            ["qvm-start", target_vm_name], timeout=60)
 
         status_item = self._get_table_item(vm_row, "State")
 
@@ -1096,7 +1096,7 @@ class QubeManagerTest(unittest.TestCase):
                          "Power state failed to update on start")
 
         self._run_command_and_process_events(
-            ["qvm-shutdown", target_vm_name], timeout=20)
+            ["qvm-shutdown", "--wait", target_vm_name], timeout=30)
 
         displayed_power_state = status_item.on_icon.status
 
@@ -1122,9 +1122,9 @@ class QubeManagerTest(unittest.TestCase):
 
         self.addCleanup(
             subprocess.call,
-            ["qvm-shutdown", target_vm_name])
+            ["qvm-shutdown", "--wait", target_vm_name])
         self._run_command_and_process_events(
-            ["qvm-start", target_vm_name], timeout=20)
+            ["qvm-start", target_vm_name], timeout=60)
 
         for i in range(self.dialog.table.rowCount()):
             call_count = self._get_table_item(
@@ -1149,7 +1149,7 @@ class QubeManagerTest(unittest.TestCase):
             self.assertIn("hypervisor", c.text(),
                           "Log for dom0 does not contain 'hypervisor'")
 
-        selected_vm = self._select_non_admin_vm().name
+        selected_vm = self._select_non_admin_vm(running=True).name
 
         self.assertTrue(self.dialog.logs_menu.isEnabled())
 

--- a/ui/settingsdlg.ui
+++ b/ui/settingsdlg.ui
@@ -1321,6 +1321,9 @@ The qube must be running to disable seamless mode; this setting is not persisten
            <property name="text">
             <string>This qube has direct network access and Qubes Firewall settings will not be used. Configure other qubes' network access in their network settings or in a dedicated firewall qube.</string>
            </property>
+           <property name="wordWrap">
+             <bool>true</bool>
+           </property>
           </widget>
          </item>
         </layout>


### PR DESCRIPTION
On OpenQA 20 isn't enough to start a VM. Also make sure previous
shutdown has finished by using qvm-shutdown --wait.

VM needs to be started at least once to have active "logs" submenu. For
this reason, choose a running VM.