### PR TITLE
Handle deleting in VM Settings without silent fails

### DIFF
--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -625,8 +625,17 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
 
         if ok and answer == self.vm.name:
             thread = common_threads.RemoveVMThread(self.vm)
+            thread.finished.connect(self.clear_threads)
+            self.threads_list.append(thread)
+
+            self.progress = QtWidgets.QProgressDialog(
+                self.tr("Deleting Qube..."), "", 0, 0)
+            self.progress.setCancelButton(None)
+            self.progress.setModal(True)
+            self.thread_closes = True
+            self.progress.show()
+
             thread.start()
-            self.done(0)
 
         elif ok:
             QtWidgets.QMessageBox.warning(


### PR DESCRIPTION
Deleting qube will now show a Delete in Progress dialog box and
not exit QApplication before QThread finishes.

fixes QubesOS/qubes-issues#5515