### PR TITLE
Removed unnecessary 'needs restarting' icons for DisposableVMs in Qube Manager

### DIFF
--- a/qubesmanager/table_widgets.py
+++ b/qubesmanager/table_widgets.py
@@ -393,8 +393,9 @@ class VmUpdateInfoWidget(QtWidgets.QWidget):
 
     def update_outdated(self):
         outdated_state = False
+        is_disposable = getattr(self.vm, 'auto_cleanup', False)
 
-        if self.vm.is_running():
+        if not is_disposable and self.vm.is_running():
             if hasattr(self.vm, 'template') and self.vm.template.is_running():
                 outdated_state = "to-be-outdated"
 
@@ -404,7 +405,8 @@ class VmUpdateInfoWidget(QtWidgets.QWidget):
                         outdated_state = "outdated"
                         break
 
-        if self.vm.klass in {'TemplateVM', 'StandaloneVM'} and \
+        if not is_disposable and \
+                self.vm.klass in {'TemplateVM', 'StandaloneVM'} and \
                 self.vm.features.get('updates-available', False):
             outdated_state = 'update'
 


### PR DESCRIPTION
fixes QubesOS/qubes-issues#5661