### PR TITLE
Fixed incorrect memory checking in VM Settings

### DIFF
--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -519,6 +519,10 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
         return msg
 
     def check_mem_changes(self):
+        if not self.include_in_balancing.isChecked():
+            # do not interfere with settings if the VM is not included in memory
+            # balancing
+            return
         if self.max_mem_size.value() < self.init_mem.value():
             QtWidgets.QMessageBox.warning(
                 self,
@@ -850,6 +854,8 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
                 self.dmm_warning_adv.hide()
                 self.dmm_warning_dev.hide()
         self.max_mem_size.setEnabled(self.include_in_balancing.isChecked())
+        if self.include_in_balancing.isChecked():
+            self.check_mem_changes()
 
     def boot_from_cdrom_button_pressed(self):
         self.save_and_apply()


### PR DESCRIPTION
When a VM is not included in memory balancing, there is no point
(and it can be actively harmful via deception) in showing warnings
about init_mem and maxmem mismatch.

fixes QubesOS/qubes-issues#5306