### PR TITLE
Fixed VM settings test

### DIFF
--- a/qubesmanager/tests/test_vm_settings.py
+++ b/qubesmanager/tests/test_vm_settings.py
@@ -393,12 +393,12 @@ class VMSettingsTest(unittest.TestCase):
 
     def test_21_nondefaultmaxmem(self):
         self.vm = self.qapp.add_new_vm("AppVM", "test-vm", "blue")
-        self.vm.maxmem = 5000
+        self.vm.maxmem = 3500
 
         self.dialog = vm_settings.VMSettingsWindow(
             self.vm, qapp=self.qtapp, qubesapp=self.qapp, init_page="advanced")
 
-        self.assertEqual(self.dialog.max_mem_size.value(), 5000)
+        self.assertEqual(self.dialog.max_mem_size.value(), 3500)
 
         self.dialog.include_in_balancing.setChecked(False)
         self._click_ok()
@@ -413,10 +413,10 @@ class VMSettingsTest(unittest.TestCase):
         self.assertFalse(self.dialog.include_in_balancing.isChecked())
 
         self.dialog.include_in_balancing.setChecked(True)
-        self.assertEqual(self.dialog.max_mem_size.value(), 5000)
+        self.assertEqual(self.dialog.max_mem_size.value(), 3500)
         self._click_ok()
 
-        self.assertEqual(self.vm.maxmem, 5000)
+        self.assertEqual(self.vm.maxmem, 3500)
 
     def test_22_initmem(self):
         self.vm = self.qapp.add_new_vm("AppVM", "test-vm", "blue")


### PR DESCRIPTION
Incorrect maxmem value caused error.

fixes QubesOS/qubes-issues#5857