### PR TITLE
Make qubesmanager resistant to missing permissions

### DIFF
--- a/qubesmanager/appmenu_select.py
+++ b/qubesmanager/appmenu_select.py
@@ -21,6 +21,7 @@
 
 import subprocess
 from PyQt5 import QtWidgets, QtCore  # pylint: disable=import-error
+from qubesadmin import exc
 
 # TODO description in tooltip
 # TODO icon
@@ -60,9 +61,12 @@ class AppmenuSelectManager:
         self.fill_apps_list(template=None)
 
     def fill_apps_list(self, template=None):
-        self.whitelisted = [line for line in subprocess.check_output(
-                ['qvm-appmenus', '--get-whitelist', self.vm.name]
-            ).decode().strip().split('\n') if line]
+        try:
+            self.whitelisted = [line for line in subprocess.check_output(
+                    ['qvm-appmenus', '--get-whitelist', self.vm.name]
+                ).decode().strip().split('\n') if line]
+        except exc.QubesException:
+            self.whitelisted = []
 
         currently_selected = [
             self.app_list.selected_list.item(i).ident
@@ -84,9 +88,13 @@ class AppmenuSelectManager:
             command.extend(['--template', template.name])
         command.append(self.vm.name)
 
-        available_appmenus = [
-            AppListWidgetItem.from_line(line)
-            for line in subprocess.check_output(command).decode().splitlines()]
+        try:
+            available_appmenus = [
+                AppListWidgetItem.from_line(line)
+                for line in subprocess.check_output(
+                    command).decode().splitlines()]
+        except exc.QubesException:
+            available_appmenus = []
 
         for app in available_appmenus:
             if app.ident in whitelist:

--- a/qubesmanager/backup_utils.py
+++ b/qubesmanager/backup_utils.py
@@ -46,7 +46,7 @@ def fill_appvms_list(dialog):
         if utils.get_feature(vm, 'internal', False) or vm.klass == 'TemplateVM':
             continue
 
-        if utils.is_running(vm, False) and vm.qid != 0:
+        if utils.is_running(vm, False) and vm.klass != 'AdminVM':
             dialog.appvm_combobox.addItem(vm.name)
 
 

--- a/qubesmanager/backup_utils.py
+++ b/qubesmanager/backup_utils.py
@@ -43,10 +43,10 @@ def fill_appvms_list(dialog):
     dialog.appvm_combobox.setCurrentIndex(0)  # current selected is null ""
 
     for vm in dialog.qubes_app.domains:
-        if vm.features.get('internal', False) or vm.klass == 'TemplateVM':
+        if utils.get_feature(vm, 'internal', False) or vm.klass == 'TemplateVM':
             continue
 
-        if vm.is_running() and vm.qid != 0:
+        if utils.is_running(vm, False) and vm.qid != 0:
             dialog.appvm_combobox.addItem(vm.name)
 
 
@@ -101,6 +101,11 @@ def select_path_button_clicked(dialog, select_file=False, read_only=False):
                     dialog.tr("Unexpected characters in path!"),
                     dialog.tr("Backup path can only contain the following "
                               "special characters: /:.,_+=() -"))
+            except Exception as ex:
+                QtWidgets.QMessageBox.warning(
+                    dialog,
+                    dialog.tr("Failed to select path!"),
+                    dialog.tr("Error {} occurred.".format(str(ex))))
 
     except subprocess.CalledProcessError:
         if not read_only:

--- a/qubesmanager/bootfromdevice.py
+++ b/qubesmanager/bootfromdevice.py
@@ -83,7 +83,7 @@ class VMBootFromDeviceWindow(ui_bootfromdevice.Ui_BootDialog,
                     self.tr("Warning!"),
                     self.tr("Qube must be turned off before booting it from "
                             "device. Please turn off the qube."))
-        except exc.QubesPropertyAccessError:
+        except exc.QubesDaemonAccessError:
             QtWidgets.QMessageBox.warning(
                 self,
                 self.tr("Warning!"),
@@ -111,7 +111,7 @@ class VMBootFromDeviceWindow(ui_bootfromdevice.Ui_BootDialog,
             try:
                 for device in domain.devices["block"]:
                     device_choice.append((str(device), device))
-            except exc.QubesException:
+            except exc.QubesDaemonAccessError:
                 # insufficient permissions
                 pass
 

--- a/qubesmanager/clone_vm.py
+++ b/qubesmanager/clone_vm.py
@@ -60,12 +60,16 @@ class CloneVMDlg(QtWidgets.QDialog, Ui_CloneVMDlg):
 
         self.update_label()
 
-        utils.initialize_widget_with_default(
-            widget=self.storage_pool,
-            choices=[(str(pool), pool) for pool in self.app.pools.values()],
-            add_qubes_default=True,
-            mark_existing_as_default=True,
-            default_value=self.app.default_pool)
+        try:
+            utils.initialize_widget_with_default(
+                widget=self.storage_pool,
+                choices=[(str(pool), pool) for pool in self.app.pools.values()],
+                add_qubes_default=True,
+                mark_existing_as_default=True,
+                default_value=self.app.default_pool)
+        except qubesadmin.exc.QubesDaemonAccessError:
+            self.storage_pool.clear()
+            self.storage_pool.addItem("(default)", qubesadmin.DEFAULT)
 
         self.set_clone_name()
 

--- a/qubesmanager/create_new_vm.py
+++ b/qubesmanager/create_new_vm.py
@@ -123,7 +123,7 @@ class NewVmDlg(QtWidgets.QDialog, Ui_NewVMDlg):
                 add_qubes_default=True,
                 mark_existing_as_default=True,
                 default_value=self.app.default_pool)
-        except qubesadmin.exc.QubesPropertyAccessError:
+        except qubesadmin.exc.QubesDaemonAccessError:
             self.storage_pool.clear()
             self.storage_pool.addItem("(default)", qubesadmin.DEFAULT)
 

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -453,7 +453,7 @@ class QubesTableModel(QAbstractTableModel):
 
         # Used for sorting
         if role == Qt.UserRole + 1:
-            if vm.klass != 'AdminVM':
+            if vm.klass == 'AdminVM':
                 return ""
             if col_name == "Type":
                 return vm.klass
@@ -572,7 +572,7 @@ class StartVMThread(common_threads.QubesThread):
 class UpdateVMThread(common_threads.QubesThread):
     def run(self):
         try:
-            if self.vm.klass != 'AdminVM':
+            if self.vm.klass == 'AdminVM':
                 subprocess.check_call(
                     ["/usr/bin/qubes-dom0-update", "--clean", "--gui"])
             else:

--- a/qubesmanager/template_manager.py
+++ b/qubesmanager/template_manager.py
@@ -345,7 +345,7 @@ class VMRow:
         table_widget.setItem(row_no, columns.index('New template'),
                              self.dummy_new_item)
 
-        self.vm_state_change(self.vm.is_running(), row_no)
+        self.vm_state_change(is_vm_running(self.vm), row_no)
 
     def vm_state_change(self, is_running, row=None):
         self.state_item.set_state(is_running)
@@ -383,6 +383,13 @@ class VMRow:
                 self.table_widget.removeCellWidget(
                     row, column_names.index('State'))
                 self.checkbox = None
+
+
+def is_vm_running(vm):
+    try:
+        return vm.is_running()
+    except exc.QubesPropertyAccessError:
+        return False
 
 
 def main():

--- a/qubesmanager/template_manager.py
+++ b/qubesmanager/template_manager.py
@@ -345,7 +345,7 @@ class VMRow:
         table_widget.setItem(row_no, columns.index('New template'),
                              self.dummy_new_item)
 
-        self.vm_state_change(is_vm_running(self.vm), row_no)
+        self.vm_state_change(utils.is_running(self.vm, False), row_no)
 
     def vm_state_change(self, is_running, row=None):
         self.state_item.set_state(is_running)
@@ -383,13 +383,6 @@ class VMRow:
                 self.table_widget.removeCellWidget(
                     row, column_names.index('State'))
                 self.checkbox = None
-
-
-def is_vm_running(vm):
-    try:
-        return vm.is_running()
-    except exc.QubesPropertyAccessError:
-        return False
 
 
 def main():

--- a/qubesmanager/tests/test_global_settings.py
+++ b/qubesmanager/tests/test_global_settings.py
@@ -105,8 +105,11 @@ class GlobalSettingsTest(unittest.TestCase):
 
         # correct defaultDispVM
         selected_default_dispvm = self.dialog.default_dispvm_combo.currentText()
-        correct_default_dispvm = \
-            str(getattr(self.qapp, 'default_dispvm', "(none)"))
+        current_default_dispvm = getattr(self.qapp, 'default_dispvm', None)
+        if current_default_dispvm is None:
+            correct_default_dispvm = "(none)"
+        else:
+            correct_default_dispvm = str(current_default_dispvm)
         self.assertTrue(
             selected_default_dispvm.startswith(correct_default_dispvm),
             "Incorrect defaultDispVM loaded")
@@ -118,11 +121,8 @@ class GlobalSettingsTest(unittest.TestCase):
 
     def test_02_dom0_updates_load(self):
         # check dom0 updates
-        try:
-            dom0_updates = self.qapp.domains[
-                'dom0'].features['service.qubes-update-check']
-        except KeyError:
-            dom0_updates = True
+        dom0_updates = self.qapp.domains[
+            'dom0'].features.get('service.qubes-update-check', True)
 
         self.assertEqual(bool(dom0_updates),
                          self.dialog.updates_dom0.isChecked(),

--- a/qubesmanager/tests/test_qube_manager.py
+++ b/qubesmanager/tests/test_qube_manager.py
@@ -1313,8 +1313,8 @@ class QubeManagerThreadTest(unittest.TestCase):
 
     @unittest.mock.patch('subprocess.check_call')
     def test_20_update_vm_thread_dom0(self, check_call):
-        vm = unittest.mock.Mock(spec=['qid'])
-        vm.qid = 0
+        vm = unittest.mock.Mock(spec=['klass'])
+        vm.klass = 'AdminVM'
         thread = qube_manager.UpdateVMThread(vm)
         thread.run()
 
@@ -1325,10 +1325,10 @@ class QubeManagerThreadTest(unittest.TestCase):
     @unittest.mock.patch('subprocess.call')
     def test_21_update_vm_thread_running(self, mock_call, mock_open):
         vm = unittest.mock.Mock(
-            spec=['qid', 'is_running', 'run_service_for_stdio', 'run_service'],
+            spec=['klass', 'is_running', 'run_service_for_stdio', 'run_service'],
             **{'is_running.return_value': True})
 
-        vm.qid = 1
+        vm.klass = 'AppVM'
         vm.run_service_for_stdio.return_value = (b'changed=no\n', None)
 
         thread = qube_manager.UpdateVMThread(vm)
@@ -1350,11 +1350,11 @@ class QubeManagerThreadTest(unittest.TestCase):
     @unittest.mock.patch('subprocess.call')
     def test_22_update_vm_thread_not_running(self, mock_call, mock_open):
         vm = unittest.mock.Mock(
-            spec=['qid', 'is_running', 'run_service_for_stdio',
+            spec=['klass', 'is_running', 'run_service_for_stdio',
                   'run_service', 'start', 'name'],
             **{'is_running.return_value': False})
 
-        vm.qid = 1
+        vm.klass = 'AppVM'
         vm.run_service_for_stdio.return_value = (b'changed=yes\n', None)
 
         thread = qube_manager.UpdateVMThread(vm)
@@ -1377,10 +1377,10 @@ class QubeManagerThreadTest(unittest.TestCase):
     @unittest.mock.patch('subprocess.check_call')
     def test_23_update_vm_thread_error(self, *_args):
         vm = unittest.mock.Mock(
-            spec=['qid', 'is_running'],
+            spec=['klass', 'is_running'],
             **{'is_running.side_effect': ChildProcessError})
 
-        vm.qid = 1
+        vm.klass = 'AppVM'
 
         thread = qube_manager.UpdateVMThread(vm)
         thread.run()

--- a/qubesmanager/utils.py
+++ b/qubesmanager/utils.py
@@ -124,6 +124,8 @@ def get_boolean_feature(vm, feature_name):
 def did_widget_selection_change(widget):
     """a simple heuristic to check if the widget text contains appropriately
     translated 'current'"""
+    if not widget.isEnabled():
+        return False
     return not translate(" (current)") in widget.currentText()
 
 

--- a/qubesmanager/utils.py
+++ b/qubesmanager/utils.py
@@ -31,6 +31,7 @@ from contextlib import suppress
 import sys
 import qasync
 from qubesadmin import events
+from qubesadmin import exc
 
 from PyQt5 import QtWidgets, QtCore, QtGui  # pylint: disable=import-error
 
@@ -91,11 +92,18 @@ class SizeSpinBox(QtWidgets.QSpinBox):
         return int(float(value) * multiplier)
 
 
+def get_feature(vm, feature_name, default_value):
+    try:
+        return vm.features.get(feature_name, default_value)
+    except exc.QubesDaemonCommunicationError:
+        return default_value
+
+
 def get_boolean_feature(vm, feature_name):
     """heper function to get a feature converted to a Bool if it does exist.
     Necessary because of the true/false in features being coded as 1/empty
     string."""
-    result = vm.features.get(feature_name, None)
+    result = get_feature(vm, feature_name, None)
     if result is not None:
         result = bool(result)
     return result

--- a/qubesmanager/utils.py
+++ b/qubesmanager/utils.py
@@ -51,8 +51,20 @@ from PyQt5 import QtWidgets, QtCore, QtGui  # pylint: disable=import-error
 
 def is_internal(vm):
     """checks if the VM is either an AdminVM or has the 'internal' features"""
-    return (vm.klass == 'AdminVM'
-            or vm.features.get('internal', False))
+    try:
+        return (vm.klass == 'AdminVM'
+                or vm.features.get('internal', False))
+    except exc.QubesDaemonCommunicationError:
+        return False
+
+
+def is_running(vm, default_state):
+    """Checks if the VM is running, returns default_state if we have
+    insufficient permissions to deteremine that."""
+    try:
+        return vm.is_running()
+    except exc.QubesPropertyAccessError:
+        return default_state
 
 
 def translate(string):

--- a/test-packages/qubesadmin/exc.py
+++ b/test-packages/qubesadmin/exc.py
@@ -11,6 +11,9 @@ class QubesVMNotStartedError(BaseException):
 class QubesPropertyAccessError(BaseException):
     pass
 
+class QubesDaemonAccessError(BaseException):
+    pass
+
 class QubesNoSuchPropertyError(BaseException):
     pass
 


### PR DESCRIPTION
All parts of qubesmanager package should now be as resilient as possible to missing permissions.
Within reason: if you can't list available labels, the create_new_vm tool will not be available etc.

fixes QubesOS/qubes-issues#5811
references QubesOS/qubes-issues#5403