### PR TITLE
Modified warning shown when destination qube for backup is unavailable

### DIFF
--- a/qubesmanager/backup.py
+++ b/qubesmanager/backup.py
@@ -170,7 +170,10 @@ class BackupVMsWindow(ui_backupdlg.Ui_Backup, QtWidgets.QWizard):
             if dest_vm_idx > -1:
                 self.appvm_combobox.setCurrentIndex(dest_vm_idx)
             else:
-                self.unrecognized_config_label.setVisible(True)
+                self.warning_running_label.setText(
+                    "NOTE: Only running qubes are listed. The profile "
+                    "lists {} as the destination qube, but it is not "
+                    "currently running.".format(dest_vm_name))
 
         if 'destination_path' in profile_data:
             dest_path = profile_data['destination_path']

--- a/qubesmanager/tests/test_backup.py
+++ b/qubesmanager/tests/test_backup.py
@@ -391,7 +391,7 @@ class BackupTest(unittest.TestCase):
         self.dialog.show()
 
         # check errors were detected
-        self.assertTrue(self.dialog.unrecognized_config_label.isVisible())
+        self.assertIn('incorrect_vm', self.dialog.warning_running_label.text())
 
     @unittest.mock.patch('qubesmanager.backup_utils.load_backup_profile')
     @unittest.mock.patch('PyQt5.QtWidgets.QMessageBox.information')

--- a/ui/backupdlg.ui
+++ b/ui/backupdlg.ui
@@ -292,7 +292,7 @@
      </widget>
     </item>
     <item row="1" column="0">
-     <widget class="QLabel" name="label">
+     <widget class="QLabel" name="warning_running_label">
       <property name="font">
        <font>
         <italic>true</italic>


### PR DESCRIPTION
Instead of scary red warning, now a gentler information that only running qubes are
available is shown. It is also shown just under the destination VM dropdown,
making it easier to notice and interpret correctly.

fixes QubesOS/qubes-issues#5427