### PR TITLE
Less intrusive max mem / init mem warning  in VM Setting

### DIFF
--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -166,6 +166,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
             self.include_in_balancing_changed)
         self.init_mem.editingFinished.connect(self.check_mem_changes)
         self.max_mem_size.editingFinished.connect(self.check_mem_changes)
+        self.check_mem_changes()
         self.boot_from_device_button.clicked.connect(
             self.boot_from_cdrom_button_pressed)
 
@@ -561,6 +562,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
         return msg
 
     def check_mem_changes(self):
+        self.warn_too_much_mem_label.setVisible(False)
         if not self.include_in_balancing.isChecked():
             # do not interfere with settings if the VM is not included in memory
             # balancing
@@ -586,13 +588,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
 
         if is_linux and \
                 self.init_mem.value() * 10 < self.max_mem_size.value():
-            self.init_mem.setValue((self.max_mem_size.value() + 9) // 10)
-            QtWidgets.QMessageBox.warning(
-                self,
-                self.tr("Warning!"),
-                self.tr("For Linux qubes, Initial memory can not be less than "
-                        "one tenth Max memory.<br>Setting initial memory "
-                        "to the minimum allowed value."))
+            self.warn_too_much_mem_label.setVisible(True)
 
     def check_warn_dispvmnetvm(self):
         if not hasattr(self.vm, 'default_dispvm'):

--- a/ui/settingsdlg.ui
+++ b/ui/settingsdlg.ui
@@ -465,19 +465,6 @@ border-width: 1px;</string>
               <property name="topMargin">
                <number>15</number>
               </property>
-              <item row="2" column="1">
-               <widget class="QSpinBox" name="vcpus">
-                <property name="enabled">
-                 <bool>true</bool>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-                <property name="value">
-                 <number>1</number>
-                </property>
-               </widget>
-              </item>
               <item row="2" column="0">
                <widget class="QLabel" name="label_4">
                 <property name="sizePolicy">
@@ -519,6 +506,19 @@ border-width: 1px;</string>
                 </property>
                </widget>
               </item>
+              <item row="2" column="1">
+               <widget class="QSpinBox" name="vcpus">
+                <property name="enabled">
+                 <bool>true</bool>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="value">
+                 <number>1</number>
+                </property>
+               </widget>
+              </item>
               <item row="0" column="1">
                <widget class="QSpinBox" name="init_mem">
                 <property name="enabled">
@@ -544,17 +544,7 @@ border-width: 1px;</string>
                 </property>
                </widget>
               </item>
-              <item row="3" column="0" colspan="2">
-               <widget class="QCheckBox" name="include_in_balancing">
-                <property name="enabled">
-                 <bool>true</bool>
-                </property>
-                <property name="text">
-                 <string>Include in memory balancing</string>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="0" colspan="3">
+              <item row="5" column="0" colspan="3">
                <widget class="QLabel" name="dmm_warning_adv">
                 <property name="font">
                  <font>
@@ -606,6 +596,127 @@ border-width: 1px;</string>
                 </property>
                 <property name="buddy">
                  <cstring>max_mem_size</cstring>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0" colspan="2">
+               <widget class="QCheckBox" name="include_in_balancing">
+                <property name="enabled">
+                 <bool>true</bool>
+                </property>
+                <property name="text">
+                 <string>Include in memory balancing</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="0" colspan="3">
+               <widget class="QLabel" name="warn_too_much_mem_label">
+                <property name="palette">
+                 <palette>
+                  <active>
+                   <colorrole role="WindowText">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>239</red>
+                      <green>41</green>
+                      <blue>41</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Text">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>239</red>
+                      <green>41</green>
+                      <blue>41</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="PlaceholderText">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="128">
+                      <red>239</red>
+                      <green>41</green>
+                      <blue>41</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </active>
+                  <inactive>
+                   <colorrole role="WindowText">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>239</red>
+                      <green>41</green>
+                      <blue>41</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Text">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>239</red>
+                      <green>41</green>
+                      <blue>41</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="PlaceholderText">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="128">
+                      <red>239</red>
+                      <green>41</green>
+                      <blue>41</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </inactive>
+                  <disabled>
+                   <colorrole role="WindowText">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>190</red>
+                      <green>190</green>
+                      <blue>190</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="Text">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>190</red>
+                      <green>190</green>
+                      <blue>190</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                   <colorrole role="PlaceholderText">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="128">
+                      <red>0</red>
+                      <green>0</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </disabled>
+                 </palette>
+                </property>
+                <property name="font">
+                 <font>
+                  <weight>75</weight>
+                  <italic>true</italic>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Linux qubes cannot utilize more than 10 times the initial memory. Setting maximum memory higher leads to unused RAM.</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignJustify|Qt::AlignVCenter</set>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
When maxmem is set to over 10x initmem, Settings will now
show a warning label and not interfere with user-provided values.
The only case in which they will interfere is maxmem<initmem.

fixes QubesOS/qubes-issues#6016