### PR TITLE
bring back "Show/Hide inactive VMs" button

### DIFF
--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -715,7 +715,6 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
         self.table.setModel(self.proxy)
         self.table.setItemDelegateForColumn(3, StateIconDelegate())
         self.table.resizeColumnsToContents()
-        self.table.setSelectionMode(QAbstractItemView.ExtendedSelection)
         selection_model = self.table.selectionModel()
         selection_model.selectionChanged.connect(self.table_selection_changed)
 

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -819,11 +819,16 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
         self.context_menu.addSeparator()
 
     def save_showing(self):
-        self.manager_settings.setValue('show/running', self.show_running.isChecked())
-        self.manager_settings.setValue('show/halted', self.show_halted.isChecked())
-        self.manager_settings.setValue('show/network', self.show_network.isChecked())
-        self.manager_settings.setValue('show/templates', self.show_templates.isChecked())
-        self.manager_settings.setValue('show/standalone', self.show_standalone.isChecked())
+        self.manager_settings.setValue('show/running',
+                self.show_running.isChecked())
+        self.manager_settings.setValue('show/halted',
+                self.show_halted.isChecked())
+        self.manager_settings.setValue('show/network',
+                self.show_network.isChecked())
+        self.manager_settings.setValue('show/templates',
+                self.show_templates.isChecked())
+        self.manager_settings.setValue('show/standalone',
+                self.show_standalone.isChecked())
         self.manager_settings.setValue('show/all', self.show_all.isChecked())
 
     def save_sorting(self):
@@ -992,7 +997,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
         self.show_network.setChecked(self.manager_settings.value(
             'show/network', "true") == "true")
         self.show_templates.setChecked(self.manager_settings.value(
-            'show/templates', "true")  == "true")
+            'show/templates', "true") == "true")
         self.show_standalone.setChecked(self.manager_settings.value(
             'show/standalone', "true") == "true")
         self.show_all.setChecked(self.manager_settings.value(
@@ -1314,7 +1319,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
                     "\nError: {}".format(str(ex))))
             return
 
-    def closeEvent(self, event):
+    def closeEvent(self, _):
         self.save_showing()
 
     # noinspection PyArgumentList

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -818,6 +818,14 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
         self.context_menu.addMenu(self.logs_menu)
         self.context_menu.addSeparator()
 
+    def save_showing(self):
+        self.manager_settings.setValue('show/running', self.show_running.isChecked())
+        self.manager_settings.setValue('show/halted', self.show_halted.isChecked())
+        self.manager_settings.setValue('show/network', self.show_network.isChecked())
+        self.manager_settings.setValue('show/templates', self.show_templates.isChecked())
+        self.manager_settings.setValue('show/standalone', self.show_standalone.isChecked())
+        self.manager_settings.setValue('show/all', self.show_all.isChecked())
+
     def save_sorting(self):
         self.manager_settings.setValue('view/sort_column',
                 self.proxy.sortColumn())
@@ -975,6 +983,20 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
         if not self.manager_settings.value("view/toolbar_visible",
                                            defaultValue=True):
             self.action_toolbar.setChecked(False)
+
+        # Restore show checkboxes
+        self.show_running.setChecked(self.manager_settings.value(
+            'show/running', "true") == "true")
+        self.show_halted.setChecked(self.manager_settings.value(
+            'show/halted', "true") == "true")
+        self.show_network.setChecked(self.manager_settings.value(
+            'show/network', "true") == "true")
+        self.show_templates.setChecked(self.manager_settings.value(
+            'show/templates', "true")  == "true")
+        self.show_standalone.setChecked(self.manager_settings.value(
+            'show/standalone', "true") == "true")
+        self.show_all.setChecked(self.manager_settings.value(
+            'show/all', "true") == "true")
 
         # load last window size
         self.resize(self.manager_settings.value("window_size",
@@ -1291,6 +1313,9 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
                     "been removed or unavailable due to policy settings."
                     "\nError: {}".format(str(ex))))
             return
+
+    def closeEvent(self, event):
+        self.save_showing()
 
     # noinspection PyArgumentList
     @pyqtSlot(name='on_action_settings_triggered')

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -37,7 +37,7 @@ from PyQt5.QtCore import (Qt, QAbstractTableModel, QObject, pyqtSlot, QEvent,
 # pylint: disable=import-error
 from PyQt5.QtWidgets import (QLineEdit, QStyledItemDelegate, QToolTip,
     QMenu, QInputDialog, QMainWindow, QProgressDialog, QStyleOptionViewItem,
-    QAbstractItemView, QMessageBox)
+    QMessageBox)
 
 # pylint: disable=import-error
 from PyQt5.QtGui import (QIcon, QPixmap, QRegExpValidator, QFont, QColor)

--- a/ui/qubemanager.ui
+++ b/ui/qubemanager.ui
@@ -52,23 +52,6 @@
     <property name="sizeConstraint">
      <enum>QLayout::SetDefaultConstraint</enum>
     </property>
-    <item row="0" column="0">
-     <layout class="QHBoxLayout" name="searchContainer">
-      <property name="spacing">
-       <number>6</number>
-      </property>
-      <property name="leftMargin">
-       <number>6</number>
-      </property>
-      <item>
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Search:</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </item>
     <item row="1" column="0">
      <widget class="QTableView" name="table">
       <property name="minimumSize">
@@ -134,107 +117,86 @@
       <attribute name="verticalHeaderCascadingSectionResizes">
        <bool>false</bool>
       </attribute>
-      <row>
-       <property name="text">
-        <string>Nowy wiersz</string>
-       </property>
-      </row>
-      <row/>
-      <row/>
-      <row/>
-      <row/>
-      <row/>
-      <row/>
-      <row/>
-      <row/>
-      <row/>
-      <column>
-       <property name="text">
-        <string/>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string/>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>Name</string>
-       </property>
-       <property name="toolTip">
-        <string>Qube name</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>State</string>
-       </property>
-       <property name="toolTip">
-        <string>Update info</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>Template</string>
-       </property>
-       <property name="toolTip">
-        <string>Qube template</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>NetVM</string>
-       </property>
-       <property name="toolTip">
-        <string>Qube netVM</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>Disk
-usage</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>Internal</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>IP</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>Include
-in backups</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>Last backup</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>Default DisposableVM
-Template</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>DisposableVM
-Template</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>Virtualization Mode</string>
-       </property>
-      </column>
      </widget>
+    </item>
+    <item row="0" column="0">
+     <layout class="QHBoxLayout" name="searchContainer">
+      <property name="spacing">
+       <number>6</number>
+      </property>
+      <property name="leftMargin">
+       <number>6</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Search:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="show_label">
+        <property name="text">
+         <string>Show:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="show_running">
+        <property name="text">
+         <string>Running</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="show_halted">
+        <property name="text">
+         <string>Halted</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="show_network">
+        <property name="text">
+         <string>Network</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="show_templates">
+        <property name="text">
+         <string>Templates</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="show_standalone">
+        <property name="text">
+         <string>Standalone</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="show_all">
+        <property name="text">
+         <string>All</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
     </item>
    </layout>
   </widget>

--- a/ui/qubemanager.ui
+++ b/ui/qubemanager.ui
@@ -108,7 +108,7 @@
        <bool>true</bool>
       </property>
       <property name="selectionMode">
-       <enum>QAbstractItemView::SingleSelection</enum>
+       <enum>QAbstractItemView::ExtendedSelection</enum>
       </property>
       <property name="selectionBehavior">
        <enum>QAbstractItemView::SelectRows</enum>

--- a/ui/qubemanager.ui
+++ b/ui/qubemanager.ui
@@ -117,6 +117,106 @@
       <attribute name="verticalHeaderCascadingSectionResizes">
        <bool>false</bool>
       </attribute>
+      <row>
+       <property name="text">
+        <string>Nowy wiersz</string>
+       </property>
+      </row>
+      <row/>
+      <row/>
+      <row/>
+      <row/>
+      <row/>
+      <row/>
+      <row/>
+      <row/>
+      <row/>
+      <column>
+       <property name="text">
+        <string/>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string/>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Name</string>
+       </property>
+       <property name="toolTip">
+        <string>Qube name</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>State</string>
+       </property>
+       <property name="toolTip">
+        <string>Update info</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Template</string>
+       </property>
+       <property name="toolTip">
+        <string>Qube template</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>NetVM</string>
+       </property>
+       <property name="toolTip">
+        <string>Qube netVM</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Disk
+usage</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Internal</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>IP</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Include
+in backups</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Last backup</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Default DisposableVM
+Template</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>DisposableVM
+Template</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Virtualization Mode</string>
+       </property>
+      </column>
      </widget>
     </item>
     <item row="0" column="0">

--- a/ui/qubemanager.ui
+++ b/ui/qubemanager.ui
@@ -146,12 +146,18 @@
         <property name="text">
          <string>Running</string>
         </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
        </widget>
       </item>
       <item>
        <widget class="QCheckBox" name="show_halted">
         <property name="text">
          <string>Halted</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -160,12 +166,18 @@
         <property name="text">
          <string>Network</string>
         </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
        </widget>
       </item>
       <item>
        <widget class="QCheckBox" name="show_templates">
         <property name="text">
          <string>Templates</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -174,12 +186,18 @@
         <property name="text">
          <string>Standalone</string>
         </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
        </widget>
       </item>
       <item>
        <widget class="QCheckBox" name="show_all">
         <property name="text">
          <string>All</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Hi, here is a first approach for fix: https://github.com/QubesOS/qubes-issues/issues/4529

![manager](https://user-images.githubusercontent.com/35405566/97807444-24d0c800-1c61-11eb-957a-027e38cad7e5.png)

It is very simple,  what is selected is being shown. Maybe we could discuss if network or templates VM's should be hidden from running.

I can add or remove some. By default all checkboxes are enabled.