### PR TITLE
Use checkbox for 'Include in Backup' column

### DIFF
--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -475,6 +475,7 @@ class QubesTableModel(QAbstractTableModel):
     def setData(self, index, value, role=Qt.EditRole):
         if not index.isValid():
             return False
+
         if role == Qt.CheckStateRole:
             col_name = self.columns_indices[index.column()]
             if col_name == "Include in backups":
@@ -491,7 +492,6 @@ class QubesTableModel(QAbstractTableModel):
         col_name = self.columns_indices[index.column()]
         if col_name == "Include in backups":
             return  Qt.ItemIsEnabled | Qt.ItemIsUserCheckable
-
         return QAbstractTableModel.flags(self, index)
 
 vm_shutdown_timeout = 20000  # in msec

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -360,7 +360,7 @@ class QubesTableModel(QAbstractTableModel):
                 "Disk Usage",
                 "Internal",
                 "IP",
-                "Include in backups",
+                "Backup",
                 "Last backup",
                 "Default DispVM",
                 "Is DVM Template",
@@ -435,7 +435,7 @@ class QubesTableModel(QAbstractTableModel):
                     self.label_pixmap[vm.icon] = icon.pixmap(icon_size)
                     return self.label_pixmap[vm.icon]
         if role == Qt.CheckStateRole:
-            if col_name == "Include in backups":
+            if col_name == "Backup":
                 return Qt.Checked if vm.inc_backup else Qt.Unchecked
         if role == Qt.FontRole:
             if col_name == "Template":
@@ -478,7 +478,7 @@ class QubesTableModel(QAbstractTableModel):
 
         if role == Qt.CheckStateRole:
             col_name = self.columns_indices[index.column()]
-            if col_name == "Include in backups":
+            if col_name == "Backup":
                 vm = self.qubes_cache.get_vm(index.row())
                 vm.vm.include_in_backups = (value == 2)
                 vm.inc_backup = (value == 2)
@@ -490,7 +490,7 @@ class QubesTableModel(QAbstractTableModel):
             return False
 
         def_flags = QAbstractTableModel.flags(self, index)
-        if self.columns_indices[index.column()] == "Include in backups":
+        if self.columns_indices[index.column()] == "Backup":
             return  def_flags | Qt.ItemIsUserCheckable
         return def_flags
 

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -480,8 +480,8 @@ class QubesTableModel(QAbstractTableModel):
             col_name = self.columns_indices[index.column()]
             if col_name == "Backup":
                 vm = self.qubes_cache.get_vm(index.row())
-                vm.vm.include_in_backups = (value == 2)
-                vm.inc_backup = (value == 2)
+                vm.vm.include_in_backups = (value == Qt.Checked)
+                vm.inc_backup = (value == Qt.Checked)
                 return True
         return False
 

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -489,10 +489,10 @@ class QubesTableModel(QAbstractTableModel):
         if not index.isValid():
             return False
 
-        col_name = self.columns_indices[index.column()]
-        if col_name == "Include in backups":
-            return  Qt.ItemIsEnabled | Qt.ItemIsUserCheckable
-        return QAbstractTableModel.flags(self, index)
+        def_flags = QAbstractTableModel.flags(self, index)
+        if self.columns_indices[index.column()] == "Include in backups":
+            return  def_flags | Qt.ItemIsUserCheckable
+        return def_flags
 
 vm_shutdown_timeout = 20000  # in msec
 vm_restart_check_timeout = 1000  # in msec


### PR DESCRIPTION
It was really simple thanks to model/view architecture.

I tried to center the checkbox on the column but it will require to subclass ItemDelegate or similar. Maybe it would be just fine with a short column header text (e.g. "Inc. in Backup") or using two lines instead one.