### PR TITLE
Multiple file log dialog

### DIFF
--- a/qubesmanager/log_dialog.py
+++ b/qubesmanager/log_dialog.py
@@ -58,7 +58,7 @@ class LogDialog(ui_logdlg.Ui_LogDialog, QtWidgets.QDialog):
                 button = QtWidgets.QPushButton(log_path)
                 button.clicked.connect(partial(self.set_current_log, log_path))
                 self.buttonsLayout.addWidget(button,
-                        count / butts_in_row, count % butts_in_row)
+                        count / btns_in_row, count % btns_in_row)
                 count += 1
 
         if count == 0:

--- a/qubesmanager/log_dialog.py
+++ b/qubesmanager/log_dialog.py
@@ -54,21 +54,13 @@ class LogDialog(ui_logdlg.Ui_LogDialog, QtWidgets.QDialog):
         btns_in_row = 3
         count = 0
         for log_path in self.logfiles:
-            if os.path.exists(log_path):
-                button = QtWidgets.QPushButton(log_path)
-                button.clicked.connect(partial(self.set_current_log, log_path))
-                self.buttonsLayout.addWidget(button,
-                        count / btns_in_row, count % btns_in_row)
-                count += 1
+            button = QtWidgets.QPushButton(log_path)
+            button.clicked.connect(partial(self.set_current_log, log_path))
+            self.buttonsLayout.addWidget(button,
+                    count / btns_in_row, count % btns_in_row)
+            count += 1
 
-        if count == 0:
-            QtWidgets.QMessageBox.warning(
-                self,
-                self.tr("Error"),
-                self.tr(
-                    "No log files where found for current selection"))
-        else:
-            self.buttonsLayout.itemAt(0).widget().click()
+        self.buttonsLayout.itemAt(0).widget().click()
 
     def copy_to_clipboard_triggered(self):
         clipboard.copy_text_to_qubes_clipboard(self.displayed_text)

--- a/qubesmanager/log_dialog.py
+++ b/qubesmanager/log_dialog.py
@@ -34,11 +34,12 @@ LOG_DISPLAY_SIZE = 1024*1024
 class LogDialog(ui_logdlg.Ui_LogDialog, QtWidgets.QDialog):
     # pylint: disable=too-few-public-methods
 
-    def __init__(self, app, log_path, parent=None):
+    def __init__(self, app, logfiles, parent=None):
         super().__init__(parent)
 
         self.app = app
-        self.logfiles = log_path
+        self.logfiles = logfiles
+        self.displayed_text = ""
 
         self.setupUi(self)
 
@@ -56,7 +57,8 @@ class LogDialog(ui_logdlg.Ui_LogDialog, QtWidgets.QDialog):
             if os.path.exists(log_path):
                 button = QtWidgets.QPushButton(log_path)
                 button.clicked.connect(partial(self.set_current_log, log_path))
-                self.buttonsLayout.addWidget(button, count / butts_in_row, count % butts_in_row)
+                self.buttonsLayout.addWidget(button,
+                        count / butts_in_row, count % butts_in_row)
                 count += 1
 
         if count == 0:
@@ -72,8 +74,8 @@ class LogDialog(ui_logdlg.Ui_LogDialog, QtWidgets.QDialog):
         clipboard.copy_text_to_qubes_clipboard(self.displayed_text)
 
     def set_current_log(self, log_path):
-        self.setWindowTitle(log_path)
         self.displayed_text = ""
+        self.setWindowTitle(log_path)
         log = open(log_path)
         log.seek(0, os.SEEK_END)
         if log.tell() > LOG_DISPLAY_SIZE:

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -1527,7 +1527,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
                         "/var/log/qubes/qrexec." + vm.name + ".log",
                     ])
 
-            logfiles = list(filter(lambda x: path.exists(x), logfiles))
+            logfiles = [x for x in logfiles if path.exists(x)]
 
             if len(logfiles) > 0:
                 log_dlg = log_dialog.LogDialog(self.qt_app, logfiles)

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -24,6 +24,7 @@
 import subprocess
 from datetime import datetime, timedelta
 from functools import partial
+from os import path
 
 from qubesadmin import exc
 from qubesadmin import utils
@@ -1526,8 +1527,18 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
                         "/var/log/qubes/qrexec." + vm.name + ".log",
                     ])
 
-            log_dlg = log_dialog.LogDialog(self.qt_app, logfiles)
-            log_dlg.exec_()
+            logfiles = list(filter(lambda x: path.exists(x), logfiles))
+
+            if len(logfiles) > 0:
+                log_dlg = log_dialog.LogDialog(self.qt_app, logfiles)
+                log_dlg.exec_()
+            else:
+                QMessageBox.warning(
+                    self,
+                    self.tr("Error"),
+                    self.tr(
+                        "No log files where found for the current selection."))
+
         except exc.QubesDaemonAccessError:
             pass
 

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -21,8 +21,6 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 #
-import os
-import os.path
 import subprocess
 from datetime import datetime, timedelta
 from functools import partial

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -689,7 +689,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
         self.context_menu.addAction(self.action_removevm)
         self.context_menu.addSeparator()
 
-        self.context_menu.addMenu(self.logs_menu)
+        self.context_menu.addAction(self.action_show_logs)
         self.context_menu.addSeparator()
 
         self.tools_context_menu = QMenu(self)
@@ -702,7 +702,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
                 lambda pos: self.open_tools_context_menu(self.toolbar, pos))
         self.action_menubar.toggled.connect(self.showhide_menubar)
         self.action_toolbar.toggled.connect(self.showhide_toolbar)
-        self.logs_menu.triggered.connect(self.show_log)
+        self.action_show_logs.triggered.connect(self.show_log)
 
         self.table.resizeColumnsToContents()
 
@@ -1029,8 +1029,6 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
 
             if not vm.updateable and vm.klass != 'AdminVM':
                 self.action_updatevm.setEnabled(False)
-
-        self.update_logs_menu()
 
     # noinspection PyArgumentList
     @pyqtSlot(name='on_action_createvm_triggered')
@@ -1428,48 +1426,32 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
     def open_tools_context_menu(self, widget, point):
         self.tools_context_menu.exec_(widget.mapToGlobal(point))
 
-    def update_logs_menu(self):
-        self.logs_menu.clear()
-        menu_empty = True
-
-        try:
-            vm_info = self.get_selected_vms()
-
-            if len(vm_info) == 1:
-                vm = vm_info[0].vm
-
-                if vm.klass == 'AdminVM':
-                    logfiles = ["/var/log/xen/console/hypervisor.log"]
-                else:
-                    logfiles = [
-                        "/var/log/xen/console/guest-" + vm.name + ".log",
-                        "/var/log/xen/console/guest-" + vm.name + "-dm.log",
-                        "/var/log/qubes/guid." + vm.name + ".log",
-                        "/var/log/qubes/qrexec." + vm.name + ".log",
-                    ]
-
-                for logfile in logfiles:
-                    if os.path.exists(logfile):
-                        action = self.logs_menu.addAction(QIcon(":/log.png"),
-                                                          logfile)
-                        action.setData(logfile)
-                        menu_empty = False
-
-            self.logs_menu.setEnabled(not menu_empty)
-        except exc.QubesDaemonAccessError:
-            pass
-
     @pyqtSlot('const QPoint&')
     def open_context_menu(self, point):
         self.context_menu.exec_(self.table.mapToGlobal(
             point + QPoint(10, 0)))
 
-    @pyqtSlot('QAction *')
-    def show_log(self, action):
-        log = str(action.data())
-        log_dlg = log_dialog.LogDialog(self.qt_app, log)
-        log_dlg.exec_()
+    def show_log(self):
+        logfiles = []
 
+        try:
+            for vm_info in self.get_selected_vms():
+                vm = vm_info.vm
+
+                if vm.klass == 'AdminVM':
+                    logfiles.append("/var/log/xen/console/hypervisor.log")
+                else:
+                    logfiles.extend([
+                        "/var/log/xen/console/guest-" + vm.name + ".log",
+                        "/var/log/xen/console/guest-" + vm.name + "-dm.log",
+                        "/var/log/qubes/guid." + vm.name + ".log",
+                        "/var/log/qubes/qrexec." + vm.name + ".log",
+                    ])
+
+            log_dlg = log_dialog.LogDialog(self.qt_app, logfiles)
+            log_dlg.exec_()
+        except exc.QubesDaemonAccessError:
+            pass
 
 def main():
     manager_utils.run_asynchronous(VmManagerWindow)

--- a/qubesmanager/utils.py
+++ b/qubesmanager/utils.py
@@ -459,7 +459,7 @@ def format_dependencies_list(dependencies):
 
 
 def loop_shutdown():
-    pending = asyncio.Task.all_tasks()
+    pending = asyncio.all_tasks()
     for task in pending:
         with suppress(asyncio.CancelledError):
             task.cancel()

--- a/ui/logdlg.ui
+++ b/ui/logdlg.ui
@@ -15,6 +15,9 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <layout class="QGridLayout" name="buttonsLayout"/>
+   </item>
+   <item>
     <widget class="QTextBrowser" name="log_text">
      <property name="font">
       <font>

--- a/ui/qubemanager.ui
+++ b/ui/qubemanager.ui
@@ -297,7 +297,7 @@ Template</string>
     <addaction name="action_open_console"/>
     <addaction name="action_set_keyboard_layout"/>
     <addaction name="separator"/>
-    <addaction name="logs_menu"/>
+    <addaction name="action_show_logs"/>
    </widget>
    <widget class="QMenu" name="menu_about">
     <property name="title">
@@ -867,6 +867,15 @@ Template</string>
    </property>
    <property name="toolTip">
     <string>Open a secure Xen console in the qube. Useful chiefly for debugging purposes: for normal operation, use &quot;Run Terminal&quot; from the Domains widget. </string>
+   </property>
+  </action>
+  <action name="action_show_logs">
+   <property name="icon">
+    <iconset>
+     <normaloff>:/log.png</normaloff>:/log.png</iconset>
+   </property>
+   <property name="text">
+    <string>Logs</string>
    </property>
   </action>
  </widget>

--- a/ui/qubemanager.ui
+++ b/ui/qubemanager.ui
@@ -350,15 +350,6 @@ Template</string>
     <property name="title">
      <string>&amp;Qube</string>
     </property>
-    <widget class="QMenu" name="logs_menu">
-     <property name="title">
-      <string>&amp;Logs</string>
-     </property>
-     <property name="icon">
-      <iconset resource="../resources.qrc">
-       <normaloff>:/log.png</normaloff>:/log.png</iconset>
-     </property>
-    </widget>
     <addaction name="action_createvm"/>
     <addaction name="action_removevm"/>
     <addaction name="action_clonevm"/>


### PR DESCRIPTION
Not very fashion but it saves a lot of clicks if you want to see many log files from one (or more) qubes.

![logdialog](https://user-images.githubusercontent.com/35405566/101241403-edd55280-36f5-11eb-8cec-7ef24875da66.png)

Probably a list should be a better solution than buttons.