### PR TITLE
VMBootFromDeviceWindow improvement and other minor fixes

### DIFF
--- a/qubesmanager/about.py
+++ b/qubesmanager/about.py
@@ -30,8 +30,8 @@ from . import ui_about  # pylint: disable=no-name-in-module
 
 # pylint: disable=too-few-public-methods
 class AboutDialog(ui_about.Ui_AboutDialog, QDialog):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, parent=None):
+        super().__init__(parent)
 
         self.setupUi(self)
 
@@ -40,15 +40,13 @@ class AboutDialog(ui_about.Ui_AboutDialog, QDialog):
             self.release.setText(release_file.read())
 
         self.ok.clicked.connect(self.accept)
-        self.releaseNotes.clicked.connect(on_release_notes_clicked)
-        self.informationNotes.clicked.connect(on_information_notes_clicked)
+        self.releaseNotes.clicked.connect(self.on_release_notes_clicked)
+        self.informationNotes.clicked.connect(self.on_information_notes_clicked)
 
+    def on_release_notes_clicked(self):
+        release_notes_dialog = ReleaseNotesDialog(self)
+        release_notes_dialog.exec_()
 
-def on_release_notes_clicked():
-    release_notes_dialog = ReleaseNotesDialog()
-    release_notes_dialog.exec_()
-
-
-def on_information_notes_clicked():
-    information_notes_dialog = InformationNotesDialog()
-    information_notes_dialog.exec_()
+    def on_information_notes_clicked(self):
+        information_notes_dialog = InformationNotesDialog(self)
+        information_notes_dialog.exec_()

--- a/qubesmanager/bootfromdevice.py
+++ b/qubesmanager/bootfromdevice.py
@@ -41,7 +41,6 @@ class VMBootFromDeviceWindow(ui_bootfromdevice.Ui_BootDialog,
             self.tr("Boot {vm} from device").format(vm=self.vm))
 
         self.buttonBox.accepted.connect(self.save_and_apply)
-        self.buttonBox.rejected.connect(self.reject)
 
         # populate buttons and such
         self.__init_buttons__()
@@ -51,9 +50,6 @@ class VMBootFromDeviceWindow(ui_bootfromdevice.Ui_BootDialog,
     def setup_application(self):
         self.qapp.setApplicationName(self.tr("Boot Qube From Device"))
         self.qapp.setWindowIcon(QtGui.QIcon.fromTheme("qubes-manager"))
-
-    def reject(self):
-        self.done(0)
 
     def save_and_apply(self):
         if self.blockDeviceRadioButton.isChecked():

--- a/qubesmanager/bootfromdevice.py
+++ b/qubesmanager/bootfromdevice.py
@@ -23,7 +23,6 @@ from . import utils
 from . import ui_bootfromdevice  # pylint: disable=no-name-in-module
 from PyQt5 import QtWidgets, QtGui  # pylint: disable=import-error
 from qubesadmin import tools
-from qubesadmin.tools import qvm_start
 from qubesadmin import exc
 
 
@@ -35,6 +34,7 @@ class VMBootFromDeviceWindow(ui_bootfromdevice.Ui_BootDialog,
         self.vm = vm
         self.qapp = qapp
         self.qubesapp = qubesapp
+        self.cdrom_location = None
 
         self.setupUi(self)
         self.setWindowTitle(
@@ -57,9 +57,9 @@ class VMBootFromDeviceWindow(ui_bootfromdevice.Ui_BootDialog,
 
     def save_and_apply(self):
         if self.blockDeviceRadioButton.isChecked():
-            cdrom_location = self.blockDeviceComboBox.currentText()
+            self.cdrom_location = self.blockDeviceComboBox.currentText()
         elif self.fileRadioButton.isChecked():
-            cdrom_location = str(self.fileVM.currentData()) + \
+            self.cdrom_location = str(self.fileVM.currentData()) + \
                              ":" + self.pathText.text()
         else:
             QtWidgets.QMessageBox.warning(
@@ -70,10 +70,7 @@ class VMBootFromDeviceWindow(ui_bootfromdevice.Ui_BootDialog,
 
         # warn user if the VM is currently running
         self.__warn_if_running__()
-
-        qvm_start.main(['--cdrom', cdrom_location, self.vm.name])
-
-        self.done(0)
+        self.accept()
 
     def __warn_if_running__(self):
         try:

--- a/qubesmanager/bootfromdevice.py
+++ b/qubesmanager/bootfromdevice.py
@@ -24,6 +24,7 @@ from . import ui_bootfromdevice  # pylint: disable=no-name-in-module
 from PyQt5 import QtWidgets, QtGui  # pylint: disable=import-error
 from qubesadmin import tools
 from qubesadmin import exc
+from qubesadmin.tools import qvm_start
 
 
 class VMBootFromDeviceWindow(ui_bootfromdevice.Ui_BootDialog,
@@ -168,8 +169,8 @@ def main(args=None):
     args = parser.parse_args(args)
     vm = args.domains.pop()
 
-    utils.run_synchronous(functools.partial(VMBootFromDeviceWindow, vm))
-
+    window = utils.run_synchronous(functools.partial(VMBootFromDeviceWindow, vm))
+    qvm_start.main(['--cdrom', window.cdrom_location, vm.name])
 
 if __name__ == "__main__":
     main()

--- a/qubesmanager/bootfromdevice.py
+++ b/qubesmanager/bootfromdevice.py
@@ -42,6 +42,7 @@ class VMBootFromDeviceWindow(ui_bootfromdevice.Ui_BootDialog,
             self.tr("Boot {vm} from device").format(vm=self.vm))
 
         self.buttonBox.accepted.connect(self.save_and_apply)
+        self.buttonBox.rejected.connect(self.reject)
 
         # populate buttons and such
         self.__init_buttons__()

--- a/qubesmanager/bootfromdevice.py
+++ b/qubesmanager/bootfromdevice.py
@@ -28,7 +28,7 @@ from qubesadmin import exc
 
 class VMBootFromDeviceWindow(ui_bootfromdevice.Ui_BootDialog,
                              QtWidgets.QDialog):
-    def __init__(self, vm, qapp, qubesapp=None, parent=None, new_vm = False):
+    def __init__(self, vm, qapp, qubesapp=None, parent=None, new_vm=False):
         super().__init__(parent)
 
         self.vm = vm

--- a/qubesmanager/bootfromdevice.py
+++ b/qubesmanager/bootfromdevice.py
@@ -38,7 +38,7 @@ class VMBootFromDeviceWindow(ui_bootfromdevice.Ui_BootDialog,
 
         self.setupUi(self)
         self.setWindowTitle(
-            self.tr("Boot {vm} from device").format(vm=self.vm.name))
+            self.tr("Boot {vm} from device").format(vm=self.vm))
 
         self.buttonBox.accepted.connect(self.save_and_apply)
         self.buttonBox.rejected.connect(self.reject)
@@ -74,7 +74,7 @@ class VMBootFromDeviceWindow(ui_bootfromdevice.Ui_BootDialog,
 
     def __warn_if_running__(self):
         try:
-            if self.vm.is_running():
+            if self.qubesapp.domains[self.vm].is_running():
                 QtWidgets.QMessageBox.warning(
                     self,
                     self.tr("Warning!"),
@@ -104,7 +104,8 @@ class VMBootFromDeviceWindow(ui_bootfromdevice.Ui_BootDialog,
         )
 
         device_choice = []
-        for domain in self.vm.app.domains:
+
+        for domain in self.qubesapp.domains:
             try:
                 for device in domain.devices["block"]:
                     device_choice.append((str(device), device))

--- a/qubesmanager/bootfromdevice.py
+++ b/qubesmanager/bootfromdevice.py
@@ -28,13 +28,14 @@ from qubesadmin import exc
 
 class VMBootFromDeviceWindow(ui_bootfromdevice.Ui_BootDialog,
                              QtWidgets.QDialog):
-    def __init__(self, vm, qapp, qubesapp=None, parent=None):
+    def __init__(self, vm, qapp, qubesapp=None, parent=None, new_vm = False):
         super().__init__(parent)
 
         self.vm = vm
         self.qapp = qapp
         self.qubesapp = qubesapp
         self.cdrom_location = None
+        self.new_vm = new_vm
 
         self.setupUi(self)
         self.setWindowTitle(
@@ -69,6 +70,9 @@ class VMBootFromDeviceWindow(ui_bootfromdevice.Ui_BootDialog,
         self.accept()
 
     def __warn_if_running__(self):
+        if self.new_vm:
+            return
+
         try:
             if self.qubesapp.domains[self.vm].is_running():
                 QtWidgets.QMessageBox.warning(

--- a/qubesmanager/bootfromdevice.py
+++ b/qubesmanager/bootfromdevice.py
@@ -169,7 +169,8 @@ def main(args=None):
     args = parser.parse_args(args)
     vm = args.domains.pop()
 
-    window = utils.run_synchronous(functools.partial(VMBootFromDeviceWindow, vm))
+    window = utils.run_synchronous(
+        functools.partial(VMBootFromDeviceWindow, vm))
     if window.result() == 1 and window.cdrom_location is not None:
         qvm_start.main(['--cdrom', window.cdrom_location, vm.name])
 

--- a/qubesmanager/bootfromdevice.py
+++ b/qubesmanager/bootfromdevice.py
@@ -170,7 +170,8 @@ def main(args=None):
     vm = args.domains.pop()
 
     window = utils.run_synchronous(functools.partial(VMBootFromDeviceWindow, vm))
-    qvm_start.main(['--cdrom', window.cdrom_location, vm.name])
+    if window.result() == 1 and window.cdrom_location is not None:
+        qvm_start.main(['--cdrom', window.cdrom_location, vm.name])
 
 if __name__ == "__main__":
     main()

--- a/qubesmanager/create_new_vm.py
+++ b/qubesmanager/create_new_vm.py
@@ -173,9 +173,6 @@ class NewVmDlg(QtWidgets.QDialog, Ui_NewVMDlg):
         self.launch_settings.stateChanged.connect(self.settings_change)
         self.install_system.stateChanged.connect(self.install_change)
 
-    def reject(self):
-        self.done(0)
-
     def accept(self):
         vmclass = self.vm_type.currentData()
 

--- a/qubesmanager/create_new_vm.py
+++ b/qubesmanager/create_new_vm.py
@@ -233,9 +233,6 @@ class NewVmDlg(QtWidgets.QDialog, Ui_NewVMDlg):
         self.progress.show()
 
     def create_finished(self):
-        self.progress.hide()
-        self.done(0)
-
         if self.thread.msg:
             QtWidgets.QMessageBox.warning(
                 self,
@@ -251,6 +248,8 @@ class NewVmDlg(QtWidgets.QDialog, Ui_NewVMDlg):
                         ['--cdrom', self.boot_dialog.cdrom_location,
                             self.name.text()])
 
+        self.progress.hide()
+        self.done(0)
 
     def type_change(self):
         template = self.template_vm.currentData()

--- a/qubesmanager/informationnotes.py
+++ b/qubesmanager/informationnotes.py
@@ -29,8 +29,8 @@ import subprocess
 class InformationNotesDialog(ui_informationnotes.Ui_InformationNotesDialog,
                              QDialog):
     # pylint: disable=too-few-public-methods
-    def __init__(self):
-        super().__init__()
+    def __init__(self, parent=None):
+        super().__init__(parent)
 
         self.setupUi(self)
         details = subprocess.check_output(

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -1275,7 +1275,8 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
     @pyqtSlot(name='on_action_createvm_triggered')
     def action_createvm_triggered(self):
         with common_threads.busy_cursor():
-            create_window = create_new_vm.NewVmDlg(self.qt_app, self.qubes_app, self)
+            create_window = create_new_vm.NewVmDlg(
+                    self.qt_app, self.qubes_app, self)
         create_window.exec_()
 
     # noinspection PyArgumentList

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -1275,7 +1275,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
     @pyqtSlot(name='on_action_createvm_triggered')
     def action_createvm_triggered(self):
         with common_threads.busy_cursor():
-            create_window = create_new_vm.NewVmDlg(self.qt_app, self.qubes_app)
+            create_window = create_new_vm.NewVmDlg(self.qt_app, self.qubes_app, self)
         create_window.exec_()
 
     # noinspection PyArgumentList
@@ -1493,8 +1493,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
         try:
             with common_threads.busy_cursor():
                 settings_window = settings.VMSettingsWindow(
-                    vm, init_page=tab, qapp=self.qt_app,
-                    qubesapp=self.qubes_app)
+                    vm, tab, self.qt_app, self.qubes_app, self)
             settings_window.show()
             self.settings_windows[vm.name] = settings_window
         except exc.QubesException as ex:
@@ -1597,7 +1596,8 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
         with common_threads.busy_cursor():
             global_settings_window = global_settings.GlobalSettingsWindow(
                 self.qt_app,
-                self.qubes_app)
+                self.qubes_app,
+                self)
         global_settings_window.show()
         self.settings_windows['global_settings_window'] = global_settings_window
 
@@ -1620,7 +1620,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
     def action_restore_triggered(self):
         with common_threads.busy_cursor():
             restore_window = restore.RestoreVMsWindow(self.qt_app,
-                                                      self.qubes_app)
+                                                      self.qubes_app, self)
         restore_window.exec_()
 
     # noinspection PyArgumentList
@@ -1670,7 +1670,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
     # noinspection PyArgumentList
     @pyqtSlot(name='on_action_about_qubes_triggered')
     def action_about_qubes_triggered(self):  # pylint: disable=no-self-use
-        about = AboutDialog()
+        about = AboutDialog(self)
         about.exec_()
 
     def createPopupMenu(self):  # pylint: disable=invalid-name

--- a/qubesmanager/releasenotes.py
+++ b/qubesmanager/releasenotes.py
@@ -27,8 +27,8 @@ from . import ui_releasenotes  # pylint: disable=no-name-in-module
 
 class ReleaseNotesDialog(ui_releasenotes.Ui_ReleaseNotesDialog, QDialog):
     # pylint: disable=too-few-public-methods
-    def __init__(self):
-        super().__init__()
+    def __init__(self, parent=None):
+        super().__init__(parent)
 
         self.setupUi(self)
 

--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -1025,7 +1025,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
 
     def boot_from_cdrom_button_pressed(self):
         boot_dialog = bootfromdevice.VMBootFromDeviceWindow(
-                self.vm, self.qapp, self.qubesapp, self)
+                self.vm.name, self.qapp, self.qubesapp, self)
         if boot_dialog.exec_():
             self.save_and_apply()
             qvm_start.main(['--cdrom', boot_dialog.cdrom_location, self.vm.name])

--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -1028,7 +1028,8 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
                 self.vm.name, self.qapp, self.qubesapp, self)
         if boot_dialog.exec_():
             self.save_and_apply()
-            qvm_start.main(['--cdrom', boot_dialog.cdrom_location, self.vm.name])
+            qvm_start.main(
+                    ['--cdrom', boot_dialog.cdrom_location, self.vm.name])
 
     def virt_mode_changed(self, new_idx):  # pylint: disable=unused-argument
         self.update_pv_warning()

--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -30,8 +30,10 @@ import traceback
 from qubesadmin.tools import QubesArgumentParser
 from qubesadmin import devices
 from qubesadmin import utils as admin_utils
+from qubesadmin.tools import qvm_start
 import qubesadmin.exc
 
+from . import bootfromdevice
 from . import utils
 from . import multiselectwidget
 from . import common_threads
@@ -1022,8 +1024,11 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
             self.check_mem_changes()
 
     def boot_from_cdrom_button_pressed(self):
-        self.save_and_apply()
-        subprocess.check_call(['qubes-vm-boot-from-device', self.vm.name])
+        boot_dialog = bootfromdevice.VMBootFromDeviceWindow(
+                self.vm, self.qapp, self.qubesapp, self)
+        if boot_dialog.exec_():
+            self.save_and_apply()
+            qvm_start.main(['--cdrom', boot_dialog.cdrom_location, self.vm.name])
 
     def virt_mode_changed(self, new_idx):  # pylint: disable=unused-argument
         self.update_pv_warning()

--- a/qubesmanager/template_manager.py
+++ b/qubesmanager/template_manager.py
@@ -35,7 +35,7 @@ class TemplateManagerWindow(
 
     def __init__(self, qt_app, qubes_app, dispatcher, parent=None):
         # pylint: disable=unused-argument
-        super().__init__()
+        super().__init__(parent)
         self.setupUi(self)
 
         self.qubes_app = qubes_app

--- a/qubesmanager/utils.py
+++ b/qubesmanager/utils.py
@@ -564,3 +564,5 @@ def run_synchronous(window_class):
 
     qt_app.exec_()
     qt_app.exit()
+
+    return window

--- a/ui/bootfromdevice.ui
+++ b/ui/bootfromdevice.ui
@@ -131,5 +131,22 @@
   </layout>
  </widget>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>BootDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>304</x>
+     <y>146</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>304</x>
+     <y>84</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/ui/bootfromdevice.ui
+++ b/ui/bootfromdevice.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>600</width>
+    <width>610</width>
     <height>170</height>
    </rect>
   </property>
@@ -27,16 +27,34 @@
        <property name="title">
         <string>Boot qube from device</string>
        </property>
-       <widget class="QWidget" name="">
+       <widget class="QWidget" name="layoutWidget">
         <property name="geometry">
          <rect>
           <x>0</x>
           <y>30</y>
           <width>581</width>
-          <height>72</height>
+          <height>74</height>
          </rect>
         </property>
         <layout class="QGridLayout" name="gridLayout_2">
+         <property name="leftMargin">
+          <number>6</number>
+         </property>
+         <property name="topMargin">
+          <number>6</number>
+         </property>
+         <property name="rightMargin">
+          <number>6</number>
+         </property>
+         <property name="bottomMargin">
+          <number>6</number>
+         </property>
+         <property name="horizontalSpacing">
+          <number>0</number>
+         </property>
+         <property name="verticalSpacing">
+          <number>6</number>
+         </property>
          <item row="0" column="0" colspan="2">
           <widget class="QRadioButton" name="blockDeviceRadioButton">
            <property name="text">

--- a/ui/bootfromdevice.ui
+++ b/ui/bootfromdevice.ui
@@ -131,22 +131,5 @@
   </layout>
  </widget>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>BootDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>304</x>
-     <y>146</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>304</x>
-     <y>84</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>


### PR DESCRIPTION
- VMBootFromDeviceWindow() doesn't start the VM itself. It now "returns" the cdrom_location so caller can handle it in a better way:
- Improved dialog size and margins
- The dialog appears now very fast.
- If the user decides to cancel it, the VM is not created. It returns to the previous dialog so he can modify something and continue, or cancel the whole process creation.

Apart from this I added a properly **parent** argument to all dialogs (except current 'Template Manager', is it going to be removed?). This is very welcome when working with big screens. Now all dialogs are created centered on the current Qube Manager window.