### PR TITLE
Pass the command line arguments to LogDialog

### DIFF
--- a/qubesmanager/log_dialog.py
+++ b/qubesmanager/log_dialog.py
@@ -84,7 +84,7 @@ def main():
     qubes_app = Qubes()
     qt_app = QtWidgets.QApplication(sys.argv)
 
-    log_window = LogDialog(qubes_app, sys.argv[1])
+    log_window = LogDialog(qubes_app, sys.argv[1:])
     log_window.show()
 
     qt_app.exec_()


### PR DESCRIPTION
instead of only the first one.  That caused argv[1] to be iterated over,
meaning that LogDialog would see it as a list of one-character
filenames.  Hilarity ensued.