### PR TITLE
Avoid spurious warnings when setting NetVM

### DIFF
--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -627,7 +627,14 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
             self.warn_too_much_mem_label.setVisible(True)
 
     def check_warn_templatenetvm(self):
-        if self.vm.klass == 'TemplateVM':
+        if self.vm.klass != 'TemplateVM':
+            return
+
+        current_netvm = self.netVM.currentData()
+        if current_netvm is None:
+            return
+
+        if current_netvm != qubesadmin.DEFAULT:
             QtWidgets.QMessageBox.warning(
                 self,
                 self.tr("Warning!"),


### PR DESCRIPTION
Resolves QubesOS/qubes-issues#6592.

Qube Manager currently shows a security warning when changing the NetVM of TemplateVMs.
This warning is generally useful in other cases, but not when disabling networking;
for example changing from from "default" to "none".

In this commit, I introduce a change to not warn when disabling networking, by setting NetVM to None. 