### PR TITLE
Fix return value of QubesTableModel.flags()

### DIFF
--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -486,7 +486,7 @@ class QubesTableModel(QAbstractTableModel):
 
     def flags(self, index):
         if not index.isValid():
-            return False
+            return Qt.NoItemFlags
 
         def_flags = QAbstractTableModel.flags(self, index)
         if self.columns_indices[index.column()] == "Backup":


### PR DESCRIPTION
The function should always return Qt::ItemFlags type, even if the index
is invalid (like in a case where qube was just removed).

Fixes QubesOS/qubes-issues#6697