### PR TITLE
Improve language

### DIFF
--- a/ui/about.ui
+++ b/ui/about.ui
@@ -84,7 +84,7 @@
      <item>
       <widget class="QPushButton" name="informationNotes">
        <property name="text">
-        <string>Version Information</string>
+        <string>Version information</string>
        </property>
       </widget>
      </item>

--- a/ui/backupdlg.ui
+++ b/ui/backupdlg.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Qubes OS - Backup qubes</string>
+   <string>Qubes Backup</string>
   </property>
   <property name="locale">
    <locale language="English" country="UnitedStates"/>
@@ -26,7 +26,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label_4">
         <property name="text">
-         <string>Select qubes to backup:</string>
+         <string>Select qubes to back up:</string>
         </property>
        </widget>
       </item>
@@ -83,7 +83,7 @@
     <item>
      <widget class="QCheckBox" name="compress_checkbox">
       <property name="text">
-       <string>Compress the backup</string>
+       <string>Compress backup</string>
       </property>
       <property name="checked">
        <bool>true</bool>
@@ -137,7 +137,7 @@
        </font>
       </property>
       <property name="text">
-       <string>Warning: unrecognized data found in configuration files. </string>
+       <string>Warning: Unrecognized data found in configuration files. </string>
       </property>
      </widget>
     </item>
@@ -238,7 +238,7 @@
           </font>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WARNING: password will be saved in dom0 in plain text.&lt;br/&gt;The file is located in dom0 in /etc/qubes/backup/qubes-manager-backup .&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WARNING: Passphrase will be saved in dom0 in plain text.&lt;br/&gt;File location: /etc/qubes/backup/qubes-manager-backup&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </widget>
        </item>
@@ -260,14 +260,14 @@
        <item row="2" column="0">
         <widget class="QLabel" name="label_11">
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reenter passphrase:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Confirm passphrase:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </widget>
        </item>
        <item row="0" column="0">
         <widget class="QLabel" name="label_12">
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Encryption / Verification&lt;br/&gt;passphrase:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Encryption passphrase:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </widget>
        </item>
@@ -307,7 +307,7 @@
        </font>
       </property>
       <property name="text">
-       <string>NOTE: Only running qubes are listed.</string>
+       <string>Note: Only running qubes are listed.</string>
       </property>
      </widget>
     </item>

--- a/ui/clonevmdlg.ui
+++ b/ui/clonevmdlg.ui
@@ -131,7 +131,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Caution&lt;/span&gt;: changing these settings can compromise your system or make the qube unable to boot. Use only if you know what you are doing.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Caution&lt;/span&gt;: Changing these settings can compromise your system or make the qube unable to boot. Use only if you know what you are doing.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="wordWrap">
           <bool>true</bool>

--- a/ui/devicelist.ui
+++ b/ui/devicelist.ui
@@ -52,7 +52,7 @@
     </rect>
    </property>
    <property name="text">
-    <string>Which PCI devices should use the no strict reset option?</string>
+    <string>Which PCI devices should use the &quot;no strict reset&quot; option?</string>
    </property>
   </widget>
   <widget class="QLabel" name="label_2">
@@ -70,7 +70,7 @@
     </font>
    </property>
    <property name="text">
-    <string>Note: use this option only if &quot;unable to reset PCI device&quot; error occurs. </string>
+    <string>Note: Use this option only if an &quot;unable to reset PCI device&quot; error occurs. </string>
    </property>
    <property name="wordWrap">
     <bool>true</bool>

--- a/ui/globalsettingsdlg.ui
+++ b/ui/globalsettingsdlg.ui
@@ -35,7 +35,7 @@
          <bool>true</bool>
         </property>
         <property name="text">
-         <string>Minimal qube memory:</string>
+         <string>Minimum qube memory:</string>
         </property>
        </widget>
       </item>
@@ -61,7 +61,7 @@
          <bool>true</bool>
         </property>
         <property name="toolTip">
-         <string>Additional memory allocated to dom0 by Qubes Memory Balancer.</string>
+         <string>Additional memory allocated to dom0 by Qubes Memory Balancer</string>
         </property>
         <property name="suffix">
          <string> MiB</string>
@@ -80,7 +80,7 @@
          <bool>true</bool>
         </property>
         <property name="toolTip">
-         <string>Additional memory allocated to dom0 by Qubes Memory Balancer.</string>
+         <string>Additional memory allocated to dom0 by Qubes Memory Balancer</string>
         </property>
         <property name="text">
          <string>Additional dom0 memory:</string>
@@ -109,7 +109,7 @@
       <item row="0" column="2">
        <widget class="QCheckBox" name="updates_vm">
         <property name="toolTip">
-         <string>Default value for new qubes; to change it for existing qubes, use buttons below.</string>
+         <string>Default value for new qubes. To change it for existing qubes, use the buttons below.</string>
         </property>
         <property name="text">
          <string>Check for qube updates by default</string>
@@ -120,12 +120,12 @@
        <widget class="QComboBox" name="itl_tmpl_updates_repo">
         <item>
          <property name="text">
-          <string>ITL template updates</string>
+          <string>Official template updates</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>ITL template updates (testing)</string>
+          <string>Official template updates (testing)</string>
          </property>
         </item>
        </widget>
@@ -157,7 +157,7 @@
       <item row="1" column="2">
        <widget class="QPushButton" name="disable_updates_all">
         <property name="text">
-         <string>Disable checking for updates for all qubes</string>
+         <string>Disable update checking for all qubes</string>
         </property>
        </widget>
       </item>
@@ -183,7 +183,7 @@
       <item row="2" column="2">
        <widget class="QPushButton" name="enable_updates_all">
         <property name="text">
-         <string>Enable checking for updates for all qubes</string>
+         <string>Enable update checking for all qubes</string>
         </property>
        </widget>
       </item>
@@ -196,7 +196,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>dom0 updates:</string>
+         <string>Dom0 updates:</string>
         </property>
        </widget>
       </item>
@@ -308,21 +308,21 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>Dom0 UpdateVM:</string>
+         <string>Dom0 update qube:</string>
         </property>
        </widget>
       </item>
       <item row="0" column="1">
        <widget class="QComboBox" name="update_vm_combo">
         <property name="toolTip">
-         <string>This is updateVM ONLY for dom0; if you want to change updateVMs for other VMs, use /etc/qubes-rpc/policy/qubes.UpdatesProxy</string>
+         <string>This update qube is only for dom0. For other qubes, see: /etc/qubes-rpc/policy/qubes.UpdatesProxy</string>
         </property>
        </widget>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
-         <string>ClockVM:</string>
+         <string>Clock qube:</string>
         </property>
        </widget>
       </item>
@@ -332,7 +332,7 @@
       <item row="2" column="0">
        <widget class="QLabel" name="label_3">
         <property name="text">
-         <string>Default netVM:</string>
+         <string>Default net qube:</string>
         </property>
        </widget>
       </item>
@@ -358,7 +358,7 @@
       <item row="4" column="0">
        <widget class="QLabel" name="label_8">
         <property name="text">
-         <string>Default DisposableVM Template:</string>
+         <string>Default disposable template:</string>
         </property>
        </widget>
       </item>
@@ -384,7 +384,7 @@
       <item row="1" column="0">
        <widget class="QLabel" name="label_13">
         <property name="text">
-         <string>Secure copy:</string>
+         <string>Global clipboard copy:</string>
         </property>
        </widget>
       </item>
@@ -394,7 +394,7 @@
       <item row="2" column="0">
        <widget class="QLabel" name="label_15">
         <property name="text">
-         <string>Secure paste:</string>
+         <string>Global clipboard paste:</string>
         </property>
        </widget>
       </item>

--- a/ui/logdlg.ui
+++ b/ui/logdlg.ui
@@ -25,7 +25,7 @@
       </font>
      </property>
      <property name="toolTip">
-      <string>Copy Dom0 clipboard to Qubes clipboard</string>
+      <string>Copy dom0 clipboard to global clipboard.</string>
      </property>
     </widget>
    </item>
@@ -56,7 +56,7 @@
         <enum>Qt::TabFocus</enum>
        </property>
        <property name="text">
-        <string>Copy to Qubes clipboard</string>
+        <string>Copy to global clipboard</string>
        </property>
        <property name="icon">
         <iconset resource="../resources.qrc">

--- a/ui/newappvmdlg.ui
+++ b/ui/newappvmdlg.ui
@@ -106,7 +106,7 @@
        <item row="7" column="1" colspan="3">
         <widget class="QCheckBox" name="launch_settings">
          <property name="text">
-          <string>launch settings after creation</string>
+          <string>Launch settings after creation</string>
          </property>
         </widget>
        </item>
@@ -180,7 +180,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Caution&lt;/span&gt;: changing these settings can compromise your system or make the qube unable to boot. Use only if you know what you are doing.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Caution&lt;/span&gt;: Changing these settings can compromise your system or make the qube unable to boot. Use only if you know what you are doing.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="wordWrap">
           <bool>true</bool>
@@ -214,14 +214,14 @@
           <bool>false</bool>
          </property>
          <property name="text">
-          <string>install system from device (also available from settings)</string>
+          <string>Install system from device (also available from settings)</string>
          </property>
         </widget>
        </item>
        <item row="1" column="0" colspan="2">
         <widget class="QCheckBox" name="provides_network">
          <property name="text">
-          <string>provides network to other qubes</string>
+          <string>Provides network access to other qubes</string>
          </property>
         </widget>
        </item>

--- a/ui/newfwruledlg.ui
+++ b/ui/newfwruledlg.ui
@@ -99,7 +99,7 @@
      <item row="1" column="1" colspan="3">
       <widget class="QComboBox" name="serviceComboBox">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Port/service can be provided as either port number (e.g. 122), port range (1024-1234) or service name (e.g. smtp) . For full list of services known, see /etc/services in dom0.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Port/service can be provided as a port number (e.g. 122), port range (1024-1234), or service name (e.g. smtp). For a full list of known services, see /etc/services in dom0.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="editable">
         <bool>true</bool>

--- a/ui/qubemanager.ui
+++ b/ui/qubemanager.ui
@@ -146,7 +146,7 @@
         <string>Name</string>
        </property>
        <property name="toolTip">
-        <string>Qube name</string>
+        <string>The name of each qube</string>
        </property>
       </column>
       <column>
@@ -154,7 +154,7 @@
         <string>State</string>
        </property>
        <property name="toolTip">
-        <string>Update info</string>
+        <string>The running state and update status of each qube</string>
        </property>
       </column>
       <column>
@@ -162,15 +162,15 @@
         <string>Template</string>
        </property>
        <property name="toolTip">
-        <string>Qube template</string>
+        <string>The template on which each qube is based</string>
        </property>
       </column>
       <column>
        <property name="text">
-        <string>NetVM</string>
+        <string>Net qube</string>
        </property>
        <property name="toolTip">
-        <string>Qube netVM</string>
+        <string>The qube that provides network access to each qube</string>
        </property>
       </column>
       <column>
@@ -178,15 +178,24 @@
         <string>Disk
 usage</string>
        </property>
+       <property name="toolTip">
+        <string>The amount of disk space used by each qube</string>
+       </property>
       </column>
       <column>
        <property name="text">
         <string>Internal</string>
        </property>
+       <property name="toolTip">
+        <string>Whether each qube is internal to the operation of the system and not intended for normal use by end users</string>
+       </property>
       </column>
       <column>
        <property name="text">
         <string>IP</string>
+       </property>
+       <property name="toolTip">
+        <string>The internal IP address assigned to each qube</string>
        </property>
       </column>
       <column>
@@ -194,27 +203,42 @@ usage</string>
         <string>Include
 in backups</string>
        </property>
+       <property name="toolTip">
+        <string>Whether each qube is included in backups by default</string>
+       </property>
       </column>
       <column>
        <property name="text">
         <string>Last backup</string>
        </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>Default DisposableVM
-Template</string>
+       <property name="toolTip">
+        <string>Timestamp indicating the last time at which each qube was backed up</string>
        </property>
       </column>
       <column>
        <property name="text">
-        <string>DisposableVM
-Template</string>
+        <string>Default disposable
+template</string>
+       </property>
+       <property name="toolTip">
+        <string>The disposable template used by default when launching disposables from each qube</string>
        </property>
       </column>
       <column>
        <property name="text">
-        <string>Virtualization Mode</string>
+        <string>Disposable
+template</string>
+       </property>
+       <property name="toolTip">
+        <string>Whether each qube is itself a disposable template</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Virtualization mode</string>
+       </property>
+       <property name="toolTip">
+        <string>The hypervisor mode used when running each qube as a virtual machine</string>
        </property>
       </column>
      </widget>
@@ -473,7 +497,7 @@ Template</string>
     <string>&amp;Delete qube</string>
    </property>
    <property name="toolTip">
-    <string>Remove an existing qube (must be stopped first)</string>
+    <string>Remove an existing qube (must be shut down first)</string>
    </property>
   </action>
   <action name="action_resumevm">
@@ -503,7 +527,7 @@ Template</string>
     <string>Emergency &amp;pause</string>
    </property>
    <property name="toolTip">
-    <string>&lt;p&gt;Pause selected qube&lt;/p&gt;&lt;p&gt;Stops all CPU activity in the selected VM until the VM is unpaused. This action does not change how much memory is allocated to the VM. (EXPERIMENTAL)&lt;/p&gt;</string>
+    <string>&lt;p&gt;Pause selected qube&lt;/p&gt;&lt;p&gt;Stops all CPU activity in the selected qube until the qube is unpaused. This action does not change how much memory is allocated to the qube. (EXPERIMENTAL)&lt;/p&gt;</string>
    </property>
   </action>
   <action name="action_shutdownvm">
@@ -518,7 +542,7 @@ Template</string>
     <string>&amp;Shutdown</string>
    </property>
    <property name="toolTip">
-    <string>Shutdown selected qube</string>
+    <string>Shut down selected qube</string>
    </property>
   </action>
   <action name="action_restartvm">
@@ -563,7 +587,7 @@ Template</string>
     <string>&amp;Update</string>
    </property>
    <property name="toolTip">
-    <string>Update qube system</string>
+    <string>Update qube</string>
    </property>
   </action>
   <action name="action_editfwrules">
@@ -590,7 +614,7 @@ Template</string>
     <string>Show graphs</string>
    </property>
    <property name="toolTip">
-    <string>Show Graphs</string>
+    <string>Show graphs</string>
    </property>
   </action>
   <action name="action_options">
@@ -622,7 +646,7 @@ Template</string>
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>&amp;NetVM</string>
+    <string>&amp;Net qube</string>
    </property>
   </action>
   <action name="action_settings">
@@ -634,7 +658,7 @@ Template</string>
     <string>S&amp;ettings</string>
    </property>
    <property name="toolTip">
-    <string>Qube Settings</string>
+    <string>Qube settings</string>
    </property>
   </action>
   <action name="action_restore">
@@ -658,7 +682,7 @@ Template</string>
     <string>&amp;Backup</string>
    </property>
    <property name="toolTip">
-    <string>Backup qubes</string>
+    <string>Back up qubes</string>
    </property>
   </action>
   <action name="action_global_settings">
@@ -676,7 +700,7 @@ Template</string>
      <normaloff>:/networking.png</normaloff>:/networking.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Qubes Network</string>
+    <string>&amp;Qubes network</string>
    </property>
    <property name="visible">
     <bool>false</bool>
@@ -728,7 +752,7 @@ Template</string>
     <string>T&amp;ype</string>
    </property>
    <property name="toolTip">
-    <string>Qube Type</string>
+    <string>Qube type</string>
    </property>
   </action>
   <action name="action_label">
@@ -848,10 +872,10 @@ Template</string>
      <normaloff>:/resumevm.png</normaloff>:/resumevm.png</iconset>
    </property>
    <property name="text">
-    <string>Start qube for Window Tools installation</string>
+    <string>Start qube for Qubes Windows Tools installation</string>
    </property>
    <property name="toolTip">
-    <string>Start qube for Window Tools installation</string>
+    <string>Start qube for Qubes Windows Tools installation</string>
    </property>
   </action>
   <action name="action_ip">
@@ -916,10 +940,10 @@ Template</string>
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Default DisposableVM Template</string>
+    <string>Default disposable template</string>
    </property>
    <property name="toolTip">
-    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Default DisposableVM Template&lt;br/&gt;&lt;br/&gt;Which qube should be used by default as a template for DisposableVMs started from this one? DisposableVMs will inherit their template's configuration and installed programs.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Default disposable template&lt;br/&gt;&lt;br/&gt;Which qube should be used by default as a template for disposables started from this one? Disposables will inherit their template's configuration and installed programs.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
    </property>
   </action>
   <action name="action_is_dvm_template">
@@ -933,7 +957,7 @@ Template</string>
     <string>DisposableVM Template</string>
    </property>
    <property name="toolTip">
-    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DisposableVM Template&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Allows using this qube as a template for DisposableVMs. The DisposableVMs will inherit the VM's state (configuration, installed programs etc.), but their state will not persist between restarts. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Disposable template&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Allows using this qube as a template for disposables. Disposables will inherit the qube's state (configuration, installed programs, etc.), but their state will not persist between restarts. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
    </property>
   </action>
   <action name="action_virt_mode">
@@ -944,7 +968,7 @@ Template</string>
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Virtualization Mode</string>
+    <string>Virtualization mode</string>
    </property>
   </action>
   <action name="action_open_console">
@@ -957,7 +981,7 @@ Template</string>
     <string>Open console in qube</string>
    </property>
    <property name="toolTip">
-    <string>Open a secure Xen console in the qube. Useful chiefly for debugging purposes: for normal operation, use &quot;Run Terminal&quot; from the Domains widget. </string>
+    <string>Open a secure Xen console in the qube. Useful chiefly for debugging purposes. For normal operation, use &quot;Run Terminal&quot; from Qubes Domains. </string>
    </property>
   </action>
   <action name="action_show_logs">
@@ -974,7 +998,7 @@ Template</string>
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Compact View</string>
+    <string>Compact view</string>
    </property>
   </action>
  </widget>

--- a/ui/qvmtemplate.ui
+++ b/ui/qvmtemplate.ui
@@ -28,7 +28,7 @@
     <item>
      <widget class="QLabel" name="label">
       <property name="text">
-       <string>Select actions to perform in &quot;Status&quot; column:</string>
+       <string>Select actions to perform in the &quot;Status&quot; column:</string>
       </property>
      </widget>
     </item>
@@ -57,7 +57,7 @@
        <bool>true</bool>
       </property>
       <property name="placeholderText">
-       <string>Use &quot;Status&quot; column to select actions to execute on a given template; when desired actions are selected, use &quot;Apply&quot; to perform them.</string>
+       <string>Use the &quot;Status&quot; column to select actions to execute on a given template. Once the desired actions are selected, use &quot;Apply&quot; to perform them.</string>
       </property>
      </widget>
     </item>

--- a/ui/restoredlg.ui
+++ b/ui/restoredlg.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Qubes OS - Restore qubes</string>
+   <string>Qubes Backup Restore</string>
   </property>
   <property name="locale">
    <locale language="English" country="UnitedStates"/>
@@ -49,27 +49,27 @@
        <item row="0" column="0">
         <widget class="QCheckBox" name="ignore_missing">
          <property name="toolTip">
-          <string>Ignore missing templates or netvms, restore VMs anyway.</string>
+          <string>Ignore missing templates and net qubes; restore qubes anyway.</string>
          </property>
          <property name="text">
-          <string>Ignore missing templates and net VMs</string>
+          <string>Ignore missing templates and net qubes.</string>
          </property>
         </widget>
        </item>
        <item row="3" column="0">
         <widget class="QCheckBox" name="ignore_uname_mismatch">
          <property name="toolTip">
-          <string>Ignore dom0 username mismatch while restoring homedir.</string>
+          <string>Ignore dom0 username mismatch when restoring home directory.</string>
          </property>
          <property name="text">
-          <string>Ignore username mismatch</string>
+          <string>Ignore dom0 username mismatch.</string>
          </property>
         </widget>
        </item>
        <item row="0" column="1">
         <widget class="QCheckBox" name="verify_only">
          <property name="text">
-          <string>Verify backup integrity, do not restore the data</string>
+          <string>Test restore to verify backup integrity (no data actually restored).</string>
          </property>
         </widget>
        </item>
@@ -113,7 +113,7 @@
           </size>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Backup file:&lt;br&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;(for old backup format select qubes.xml file)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Backup file:&lt;br&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;(For legacy backup formats, select the qubes.xml file.)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
@@ -169,7 +169,7 @@
        <item row="1" column="0">
         <widget class="QLabel" name="label_5">
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Decryption / Verification&lt;br/&gt;passphrase:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Decryption passphrase:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </widget>
        </item>
@@ -272,7 +272,7 @@ p, li { white-space: pre-wrap; }
     <item>
      <widget class="QCheckBox" name="showFileDialog">
       <property name="text">
-       <string>When finished, open file selection dialog to allow me to unmount the disk</string>
+       <string>When finished, open file selection dialog to allow me to unmount the disk.</string>
       </property>
      </widget>
     </item>

--- a/ui/settingsdlg.ui
+++ b/ui/settingsdlg.ui
@@ -134,7 +134,7 @@
                <bool>true</bool>
               </property>
               <property name="text">
-               <string>System storage max. size:</string>
+               <string>System storage max size:</string>
               </property>
              </widget>
             </item>
@@ -166,7 +166,7 @@
             <item row="0" column="0">
              <widget class="QLabel" name="label_3">
               <property name="text">
-               <string>Private storage max. size:</string>
+               <string>Private storage max size:</string>
               </property>
               <property name="buddy">
                <cstring>max_priv_storage</cstring>
@@ -192,7 +192,7 @@
          <item row="2" column="1">
           <widget class="QGroupBox" name="networking_groupbox">
            <property name="title">
-            <string>Networking</string>
+            <string>Net qube</string>
            </property>
            <layout class="QFormLayout" name="formLayout_3">
             <property name="fieldGrowthPolicy">
@@ -371,7 +371,7 @@ border-width: 1px;</string>
             <item row="2" column="3">
              <widget class="QLabel" name="warn_netvm_dispvm">
               <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Caution:&lt;/span&gt; The Default DisposableVM Template (see the Advanced tab) has a different Networking setting than this qube. This configuration may result in unexpected network access. For example, you may have set this qube's Networking to &amp;quot;none&amp;quot; in order to prevent any data from being transmitted out. However, if the Default DisposableVM Template's Networking is set to &amp;quot;sys-firewall,&amp;quot; then a DisposableVM started from this qube may be able to transmit data out, contrary to your intention. You may wish to set the Default DisposableVM Template for this qube to one with equally restrictive Networking settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Caution:&lt;/span&gt; The default disposable template (see the Advanced tab) has a different net qube setting than this qube. This configuration may result in unexpected network access. For example, you may have set this qube's net qube to &amp;quot;none&amp;quot; in order to prevent any data from being transmitted out. However, if the default disposable template's net qube is set to &amp;quot;sys-firewall,&amp;quot; then a disposable started from this qube may be able to transmit data out, contrary to your intention. You may wish to set the default disposable template for this qube to one with equally restrictive networking settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="text">
                <string/>
@@ -401,7 +401,7 @@ border-width: 1px;</string>
             <item row="2" column="1" colspan="2">
              <widget class="QComboBox" name="netVM">
               <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&amp;quot;default ([name])&amp;quot; denotes system-wide default - if the default is changed in Global Settings, the networking qube will change. &lt;br/&gt;If you want to keep using a given networking qube regardless of system settings, select &amp;quot;[name]&amp;quot;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&amp;quot;default ([name])&amp;quot; denotes the system-wide default. If the default is changed in Global Settings, the net qube will change. &lt;br/&gt;If you want to keep using a given net qube regardless of system settings, select &amp;quot;[name]&amp;quot;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
              </widget>
             </item>
@@ -425,7 +425,7 @@ border-width: 1px;</string>
             <item row="2" column="0">
              <widget class="QLabel" name="label_18">
               <property name="text">
-               <string>Networking:</string>
+               <string>Net qube:</string>
               </property>
               <property name="buddy">
                <cstring>netVM</cstring>
@@ -481,7 +481,7 @@ border-width: 1px;</string>
                  </sizepolicy>
                 </property>
                 <property name="text">
-                 <string>VCPUs no.:</string>
+                 <string>VCPUs:</string>
                 </property>
                 <property name="buddy">
                  <cstring>vcpus</cstring>
@@ -752,17 +752,17 @@ border-width: 1px;</string>
               <item row="3" column="0">
                <widget class="QCheckBox" name="dvm_template_checkbox">
                 <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Allows using this qube as a template for DisposableVMs. The DisposableVMs will inherit the VM's state (configuration, installed programs etc.), but their state will not persist between restarts. &lt;/p&gt;&lt;p&gt;Setting this option will cause this qube to be listed as an option in the &amp;quot;Default DisposableVM Template&amp;quot; dropdown for all other qubes. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Allows using this qube as a template for disposables. Disposables will inherit the qube's state (configuration, installed programs, etc.), but their state will not persist between restarts. &lt;/p&gt;&lt;p&gt;Setting this option will cause this qube to be listed as an option in the &amp;quot;Default disposable template&amp;quot; list for all other qubes. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                 <property name="text">
-                 <string>Disposable VM Template</string>
+                 <string>Disposable template</string>
                 </property>
                </widget>
               </item>
               <item row="8" column="0" colspan="2">
                <widget class="QPushButton" name="boot_from_device_button">
                 <property name="text">
-                 <string>Boot qube from CDROM</string>
+                 <string>Boot qube from CD-ROM</string>
                 </property>
                </widget>
               </item>
@@ -772,7 +772,7 @@ border-width: 1px;</string>
                  <widget class="QPushButton" name="seamless_on_button">
                   <property name="toolTip">
                    <string>Windows (with Qubes Windows Tools installed) only.
-The qube must be running to enable seamless mode;  this setting is not persistent.</string>
+The qube must be running to enable seamless mode. This setting is not persistent.</string>
                   </property>
                   <property name="text">
                    <string>Enable seamless mode</string>
@@ -783,7 +783,7 @@ The qube must be running to enable seamless mode;  this setting is not persisten
                  <widget class="QPushButton" name="seamless_off_button">
                   <property name="toolTip">
                    <string>Windows (with Qubes Windows Tools installed) only.
-The qube must be running to disable seamless mode; this setting is not persistent.</string>
+The qube must be running to disable seamless mode. This setting is not persistent.</string>
                   </property>
                   <property name="text">
                    <string>Disable seamless mode</string>
@@ -797,10 +797,10 @@ The qube must be running to disable seamless mode; this setting is not persisten
                 <item>
                  <widget class="QLabel" name="label_26">
                   <property name="toolTip">
-                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Which qube should be used by default as a template for DisposableVMs started from this one? DisposableVMs will inherit their template's configuration and installed programs.&lt;br/&gt;For a qube to to appear in this list, it must have the &amp;quot;DisposableVM Template&amp;quot; checkbox enabled. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Which qube should be used by default as a template for disposables started from this one? Disposables will inherit their template's configuration and installed programs.&lt;br/&gt;For a qube to to appear in this list, it must have the &amp;quot;Disposable template&amp;quot; setting enabled. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                   </property>
                   <property name="text">
-                   <string>Default DisposableVM Template</string>
+                   <string>Default disposable template</string>
                   </property>
                   <property name="buddy">
                    <cstring>default_dispvm</cstring>
@@ -816,7 +816,7 @@ The qube must be running to disable seamless mode; this setting is not persisten
                    </sizepolicy>
                   </property>
                   <property name="toolTip">
-                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Which qube should be used by default as a template for DisposableVMs started from this one? DisposableVMs will inherit their template's configuration and installed programs.&lt;br/&gt;For a qube to to appear in this list, it must have the &amp;quot;DisposableVM Template&amp;quot; checkbox enabled. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Which qube should be used by default as a template for disposables started from this one? Disposables will inherit their template's configuration and installed programs.&lt;br/&gt;For a qube to to appear in this list, it must have the &amp;quot;Disposable template&amp;quot; setting enabled. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                   </property>
                  </widget>
                 </item>
@@ -864,7 +864,7 @@ The qube must be running to disable seamless mode; this setting is not persisten
               </sizepolicy>
              </property>
              <property name="title">
-              <string>Window Options</string>
+              <string>Window options</string>
              </property>
              <layout class="QGridLayout" name="gridLayout_12">
               <item row="0" column="0">
@@ -1107,7 +1107,7 @@ The qube must be running to disable seamless mode; this setting is not persisten
                  </font>
                 </property>
                 <property name="text">
-                 <string>PVH mode is recommended if possible (Linux kernel 4.11 or newer, no PCI passthrough). For Windows qubes always use HVM.</string>
+                 <string>PVH mode is recommended, if possible (Linux kernel 4.11 or newer, no PCI passthrough). For Windows qubes, always use HVM.</string>
                 </property>
                 <property name="wordWrap">
                  <bool>true</bool>
@@ -1194,7 +1194,7 @@ The qube must be running to disable seamless mode; this setting is not persisten
          <item row="10" column="0" colspan="2">
           <widget class="QLabel" name="label_22">
            <property name="text">
-            <string>NOTE:  To block all network access, set Networking to (none) on the Basic settings tab. This tab provides a very simplified firewall configuration. All DNS requests and ICMP (pings) will be allowed. For more granular control, use the command line tool qvm-firewall.</string>
+            <string>NOTE:  To block all network access, set the net qube to '(none)' on the Basic settings tab. This tab provides a very simplified firewall configuration. All DNS requests and ICMP (pings) will be allowed. For more granular control, use the command line tool 'qvm-firewall'.</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -1251,7 +1251,7 @@ The qube must be running to disable seamless mode; this setting is not persisten
             </font>
            </property>
            <property name="text">
-            <string>This qube has no networking - it will not have any network access anyway.</string>
+            <string>This qube has no net qube. It will not have any network access anyway.</string>
            </property>
            <property name="wordWrap">
             <bool>true</bool>
@@ -1268,7 +1268,7 @@ The qube must be running to disable seamless mode; this setting is not persisten
          <item row="7" column="0">
           <widget class="QLabel" name="firewal_rules_label">
            <property name="text">
-            <string>List of allowed (whitelisted) addresses:</string>
+            <string>List of allowed addresses:</string>
            </property>
           </widget>
          </item>
@@ -1319,7 +1319,7 @@ The qube must be running to disable seamless mode; this setting is not persisten
             </font>
            </property>
            <property name="text">
-            <string>Networking qube does not support 'qubes-firewall' - firewall restrictions will not be applied.</string>
+            <string>Net qube does not support 'qubes-firewall'. Firewall restrictions will not be applied.</string>
            </property>
           </widget>
          </item>
@@ -1370,7 +1370,7 @@ The qube must be running to disable seamless mode; this setting is not persisten
             </font>
            </property>
            <property name="text">
-            <string>Firewall has been modified manually - please use qvm-firewall for any further configuration.</string>
+            <string>Firewall has been modified manually. Please use the 'qvm-firewall' command in dom0 for any further configuration.</string>
            </property>
           </widget>
          </item>
@@ -1492,7 +1492,7 @@ The qube must be running to disable seamless mode; this setting is not persisten
            <item>
             <widget class="QRadioButton" name="policy_allow_radio_button">
              <property name="text">
-              <string>Allow all outgoing Internet connections</string>
+              <string>Allow all outgoing connections</string>
              </property>
             </widget>
            </item>
@@ -1502,7 +1502,7 @@ The qube must be running to disable seamless mode; this setting is not persisten
               <string>Changing firewall settings does NOT affect existing connections.</string>
              </property>
              <property name="text">
-              <string>Limit outgoing Internet connections to ...</string>
+              <string>Limit outgoing connections to ...</string>
              </property>
             </widget>
            </item>
@@ -1555,7 +1555,7 @@ The qube must be running to disable seamless mode; this setting is not persisten
             </font>
            </property>
            <property name="text">
-            <string>This qube has direct network access and Qubes Firewall settings will not be used. Configure other qubes' network access in their network settings or in a dedicated firewall qube.</string>
+            <string>This qube has direct network access. Therefore, Qubes firewall settings cannot be used. Configure other qubes' network access in their network settings or in a dedicated firewall qube.</string>
            </property>
            <property name="wordWrap">
             <bool>true</bool>
@@ -1591,7 +1591,7 @@ The qube must be running to disable seamless mode; this setting is not persisten
               <string notr="true">color: rgb(255, 0, 0)</string>
              </property>
              <property name="text">
-              <string>You've enabled dynamic memory balancing, some devices might not work!</string>
+              <string>You've enabled dynamic memory balancing. Some devices might not work!</string>
              </property>
             </widget>
            </item>
@@ -1605,7 +1605,7 @@ The qube must be running to disable seamless mode; this setting is not persisten
               </font>
              </property>
              <property name="text">
-              <string>To modify PCI devices you have to turn off the qube.</string>
+              <string>To modify PCI devices, you must first shut down the qube.</string>
              </property>
             </widget>
            </item>
@@ -1619,7 +1619,7 @@ The qube must be running to disable seamless mode; this setting is not persisten
               </font>
              </property>
              <property name="text">
-              <string>Currently PVH qubes don't support PCI passthrough. Select another virtualization mode if you want to add PCI devices</string>
+              <string>Currently, PVH qubes don't support PCI passthrough. Select another virtualization mode if you want to add PCI devices.</string>
              </property>
             </widget>
            </item>
@@ -1652,7 +1652,7 @@ The qube must be running to disable seamless mode; this setting is not persisten
             </sizepolicy>
            </property>
            <property name="text">
-            <string>Refresh Applications</string>
+            <string>Refresh applications</string>
            </property>
           </widget>
          </item>
@@ -1682,7 +1682,7 @@ The qube must be running to disable seamless mode; this setting is not persisten
          <item row="11" column="0" colspan="2">
           <widget class="QLabel" name="label_7">
            <property name="text">
-            <string>Checked services will be turned on.</string>
+            <string>Selected services will be turned on.</string>
            </property>
           </widget>
          </item>
@@ -1696,7 +1696,7 @@ The qube must be running to disable seamless mode; this setting is not persisten
          <item row="12" column="0" colspan="2">
           <widget class="QLabel" name="label_8">
            <property name="text">
-            <string>Unchecked services will be turned off.</string>
+            <string>Unselected services will be turned off.</string>
            </property>
           </widget>
          </item>

--- a/ui/templateinstallconfirmdlg.ui
+++ b/ui/templateinstallconfirmdlg.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Template Install Confirmation</string>
+   <string>Template installation confirmation</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/ui/templatemanager.ui
+++ b/ui/templatemanager.ui
@@ -102,7 +102,7 @@
         <item>
          <widget class="QPushButton" name="clear_selection_button">
           <property name="text">
-           <string>Clear Selection</string>
+           <string>Clear selection</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
- Fix capitalization, grammar, and punctuation
- Use names and terminology more consistently
  (QubesOS/qubes-issues#4723)
- Replace "VM" with "qube" (QubesOS/qubes-issues#1015)
- Add explanatory tooltips (QubesOS/qubes-issues#2211)
- Wording improvements