### PR TITLE
Update qube_manager.py

### DIFF
--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -627,7 +627,8 @@ class UpdateVMThread(common_threads.QubesThread):
                                 stderr.decode('ascii')))
                 self.vm.run_service("qubes.InstallUpdatesGUI",
                                     user="root", wait=False)
-        except (ChildProcessError, subprocess.CalledProcessError, exc.QubesException) as ex:
+        except (ChildProcessError, subprocess.CalledProcessError,
+                exc.QubesException) as ex:
             self.msg = (self.tr("Error on qube update!"), str(ex))
 
 
@@ -640,7 +641,8 @@ class RunCommandThread(common_threads.QubesThread):
     def run(self):
         try:
             self.vm.run(self.command_to_run)
-        except (ChildProcessError, subprocess.CalledProcessError, exc.QubesException) as ex:
+        except (ChildProcessError, subprocess.CalledProcessError,
+                exc.QubesException) as ex:
             self.msg = (self.tr("Error while running command!"), str(ex))
 
 class QubesProxyModel(QSortFilterProxyModel):

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -627,7 +627,7 @@ class UpdateVMThread(common_threads.QubesThread):
                                 stderr.decode('ascii')))
                 self.vm.run_service("qubes.InstallUpdatesGUI",
                                     user="root", wait=False)
-        except (ChildProcessError, exc.QubesException) as ex:
+        except (ChildProcessError, subprocess.CalledProcessError, exc.QubesException) as ex:
             self.msg = (self.tr("Error on qube update!"), str(ex))
 
 
@@ -640,7 +640,7 @@ class RunCommandThread(common_threads.QubesThread):
     def run(self):
         try:
             self.vm.run(self.command_to_run)
-        except (ChildProcessError, exc.QubesException) as ex:
+        except (ChildProcessError, subprocess.CalledProcessError, exc.QubesException) as ex:
             self.msg = (self.tr("Error while running command!"), str(ex))
 
 class QubesProxyModel(QSortFilterProxyModel):


### PR DESCRIPTION
Catch subprocess.CalledProcessError rather than let the error abort.

It should fix the issue when qube-manager aborts when executed command exits with error.

The issue is mentioned many times in many places. See https://github.com/QubesOS/qubes-issues/issues/7278

DISCLAIMER: not tested, as I do not have a good testing environment