### PR TITLE
Making Qubes Manager REUSE compliant 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
 *.pyc
 *.pyo
 *~

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
 include:
   - project: 'QubesOS/qubes-continuous-integration'
     file: '/r4.1/gitlab-base.yml'

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
 [MASTER]
 persistent=no
 ignore=tests,

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,8 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: Qubes
+Upstream-Contact: Michael Carbone <michael@qubes-os.org>
+Source: https://github.com/NSfsfe/qubes-manager.git
+
+Files: icons/*
+Copyright: 2015 Qubes
+License: GPL-2.0-only

--- a/LICENSES/GPL-2.0-only.txt
+++ b/LICENSES/GPL-2.0-only.txt
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2015 2015 Michael Carbone, <michael@qubes-os.org> et al.
+
+SPDX-License-Identifier: GPL-2.0-only
+-->
+
 Qubes Manager
 ==============
 

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
 # WARNING: those requirements are used only for travis-ci.org
 # they SHOULD NOT be used under normal conditions; use system package manager
 coverage

--- a/icons/on-icon/off.png.license
+++ b/icons/on-icon/off.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2015 2015 Michael Carbone, <michael@qubes-os.org> et al.
+
+SPDX-License-Identifier: GPL-2.0-only

--- a/qubesmanager/.gitignore
+++ b/qubesmanager/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
 qrc_resources.py
 resources_rc.py
 ui_*.py

--- a/qubesmanager/__init__.py
+++ b/qubesmanager/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+

--- a/qubesmanager/about.py
+++ b/qubesmanager/about.py
@@ -1,4 +1,10 @@
 #!/usr/bin/python3
+
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+
 # coding=utf-8
 #
 # The Qubes OS Project, http://www.qubes-os.org

--- a/qubesmanager/backup.py
+++ b/qubesmanager/backup.py
@@ -1,5 +1,10 @@
 #!/usr/bin/python3
 #
+
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
 # The Qubes OS Project, http://www.qubes-os.org
 #
 # Copyright (C) 2012  Agnieszka Kostrzewa <agnieszka.kostrzewa@gmail.com>

--- a/qubesmanager/backup_utils.py
+++ b/qubesmanager/backup_utils.py
@@ -1,4 +1,9 @@
 #!/usr/bin/python2
+
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
 #
 # The Qubes OS Project, http://www.qubes-os.org
 #

--- a/qubesmanager/clipboard.py
+++ b/qubesmanager/clipboard.py
@@ -1,4 +1,9 @@
 #!/usr/bin/python3
+
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
 #
 # The Qubes OS Project, http://www.qubes-os.org
 #

--- a/qubesmanager/clone_vm.py
+++ b/qubesmanager/clone_vm.py
@@ -1,4 +1,9 @@
 #!/usr/bin/python3
+
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
 #
 # The Qubes OS Project, http://www.qubes-os.org
 #

--- a/qubesmanager/common_threads.py
+++ b/qubesmanager/common_threads.py
@@ -1,5 +1,10 @@
 #!/usr/bin/python3
 #
+
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
 # The Qubes OS Project, http://www.qubes-os.org
 #
 # Copyright (C) 2018  Donoban <donoban@riseup.net>

--- a/qubesmanager/global_settings.css
+++ b/qubesmanager/global_settings.css
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2015 2015 Michael Carbone, <michael@qubes-os.org> et al.
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
 
 QPushButton {
     padding: 10px;

--- a/qubesmanager/global_settings.py
+++ b/qubesmanager/global_settings.py
@@ -1,4 +1,9 @@
 #!/usr/bin/python3
+
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
 #
 # The Qubes OS Project, http://www.qubes-os.org
 #

--- a/qubesmanager/i18n/.gitignore
+++ b/qubesmanager/i18n/.gitignore
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2015 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
 *.qm

--- a/qubesmanager/i18n/qubesmanager_en.ts
+++ b/qubesmanager/i18n/qubesmanager_en.ts
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS><TS version="2.0" language="en" sourcelanguage="">
 <context>

--- a/qubesmanager/i18n/qubesmanager_es.ts
+++ b/qubesmanager/i18n/qubesmanager_es.ts
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+
+
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS><TS version="2.0" language="es" sourcelanguage="">
 <context>

--- a/qubesmanager/informationnotes.py
+++ b/qubesmanager/informationnotes.py
@@ -1,4 +1,10 @@
 #!/usr/bin/python3
+
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+
 # coding=utf-8
 #
 # The Qubes OS Project, http://www.qubes-os.org

--- a/qubesmanager/log_dialog.py
+++ b/qubesmanager/log_dialog.py
@@ -1,4 +1,10 @@
 #!/usr/bin/python3
+
+
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
 #
 # The Qubes OS Project, http://www.qubes-os.org
 #

--- a/qubesmanager/mount_for_backup.sh
+++ b/qubesmanager/mount_for_backup.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+
 #args:
 # 1) device path
 # 2) mountpoint name

--- a/qubesmanager/multiselectwidget.py
+++ b/qubesmanager/multiselectwidget.py
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+
+
 from PyQt5 import QtCore, QtWidgets  # pylint: disable=import-error
 from . import ui_multiselectwidget  # pylint: disable=no-name-in-module
 

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -1,4 +1,10 @@
 #!/usr/bin/python3
+
+
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
 #
 # The Qubes OS Project, http://www.qubes-os.org
 #

--- a/qubesmanager/qvm_about.sh
+++ b/qubesmanager/qvm_about.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/sh
+
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
 xl info|grep xen_version
 uname -sr
 echo "  "

--- a/qubesmanager/qvm_template_gui.py
+++ b/qubesmanager/qvm_template_gui.py
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+
+
 import asyncio
 import collections
 from datetime import datetime

--- a/qubesmanager/releasenotes.py
+++ b/qubesmanager/releasenotes.py
@@ -1,4 +1,11 @@
 #!/usr/bin/python3
+
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+
+
 # coding=utf-8
 #
 # The Qubes OS Project, http://www.qubes-os.org

--- a/qubesmanager/tests/__init__.py
+++ b/qubesmanager/tests/__init__.py
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+
+
 import asyncio
 import sys
 

--- a/qubesmanager/tests/test_backup.py
+++ b/qubesmanager/tests/test_backup.py
@@ -1,4 +1,9 @@
 #!/usr/bin/python3
+
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
 #
 # The Qubes OS Project, https://www.qubes-os.org/
 #

--- a/qubesmanager/tests/test_backup_utils.py
+++ b/qubesmanager/tests/test_backup_utils.py
@@ -1,4 +1,10 @@
 #!/usr/bin/python3
+
+
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
 #
 # The Qubes OS Project, https://www.qubes-os.org/
 #

--- a/qubesmanager/tests/test_clone_vm.py
+++ b/qubesmanager/tests/test_clone_vm.py
@@ -1,4 +1,9 @@
 #!/usr/bin/python3
+
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
 #
 # The Qubes OS Project, https://www.qubes-os.org/
 #

--- a/qubesmanager/tests/test_global_settings.py
+++ b/qubesmanager/tests/test_global_settings.py
@@ -1,4 +1,9 @@
 #!/usr/bin/python3
+
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
 #
 # The Qubes OS Project, https://www.qubes-os.org/
 #

--- a/qubesmanager/tests/test_vm_settings.py
+++ b/qubesmanager/tests/test_vm_settings.py
@@ -1,4 +1,9 @@
 #!/usr/bin/python3
+
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
 #
 # The Qubes OS Project, https://www.qubes-os.org/
 #

--- a/qubesmanager/utils.py
+++ b/qubesmanager/utils.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+
 #
 # The Qubes OS Project, https://www.qubes-os.org
 #

--- a/test-packages/qubesadmin/__init__.py
+++ b/test-packages/qubesadmin/__init__.py
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+
+
 class Qubes(object):
     pass
 

--- a/test-packages/qubesadmin/backup/__init__.py
+++ b/test-packages/qubesadmin/backup/__init__.py
@@ -1,1 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+
+
 pass

--- a/test-packages/qubesadmin/backup/restore/__init__.py
+++ b/test-packages/qubesadmin/backup/restore/__init__.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+
 class BackupRestore(object):
 
     options = object()

--- a/test-packages/qubesadmin/devices.py
+++ b/test-packages/qubesadmin/devices.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+
 ### mock qubesadmin.devices module
 
 class DeviceAssignment(object):

--- a/test-packages/qubesadmin/events.py
+++ b/test-packages/qubesadmin/events.py
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+
+
 class EventsDispatcher(object):
 
     def add_handler(self, *args):

--- a/test-packages/qubesadmin/exc.py
+++ b/test-packages/qubesadmin/exc.py
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+
+
 ### mock qubesadmin.exc module
 # pylint: disable=unused-variable
 

--- a/test-packages/qubesadmin/firewall.py
+++ b/test-packages/qubesadmin/firewall.py
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+
+
 ### mock qubesadmin.firewall module
 
 class Rule(object):

--- a/test-packages/qubesadmin/tools/__init__.py
+++ b/test-packages/qubesadmin/tools/__init__.py
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+
+
 ### mock qubesadmin.tools module
 
 class QubesArgumentParser(object):

--- a/test-packages/qubesadmin/tools/qvm_start.py
+++ b/test-packages/qubesadmin/tools/qvm_start.py
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+
+
 ### mock qvm_start module
 
 def main(*args, **kwargs):

--- a/test-packages/qubesadmin/utils.py
+++ b/test-packages/qubesadmin/utils.py
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2015 Michael Carbone, <michael@qubes-os.org> et al.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+
+
 ### mock qubesadmin.utils module
 
 def parse_size(*args, **kwargs):


### PR DESCRIPTION
Hello,

By way of introduction, I am Niharika Singhal from the Free Software Foundation Europe, and the REUSE Booster program. Thank you for contacting us and we are happy to help you out with the implementation of REUSE. After a check on your repository, I would like to propose some updates regarding your copyright and licensing information. The REUSE specifications intend to make licensing easier with best practices to display legal information through comment headers on source files that can be easily human and machine readable. You can check this screencast: 
https://download.fsfe.org/videos/reuse/screencasts/reuse-tool.gif 

Please keep in mind that this merge request is intended to be a practical example of how REUSE looks like. 

I would also like to make some remarks to be considered to make your full project REUSE compliant. 

Feel completely free to adopt these specifications by merging this pull request. 

# REUSE Features: 

SPDX copyright and license comment headers for all relevant files (please be aware that in the current state of the repository, I was able to add headers to all the directories. However, some files might miss this feature depending on the type of the file. For example, .tx/config, debian/changelog, debian/compat and debian/control files, among others.) If you are interested in implementing REUSE specification, I hope this merge request can help you to do so. 


# LICENSES directory in the root of the project with the licenses used on the repository: 

I included in this directory, the file that contained the license for your project (GPL 2.0 only) text. If some pieces of your project use a different license, please add their license text to the LICENSES directory. 

# Files missing copyright and licensing information: 

I noticed that your project does not have the copyright and license information displayed in a comment header. According to the REUSE specifications, the comment headers MUST contain the SPDX Tag. For this, we recommend to update the headers, or at least the SPDX-License-Identifier as in this practical example. 

Please also double check if the personal information in the headers is correct and consistent, in the case of several copyright holders please update that information in the headers. 

In case you want to license certain files under a different license, special attention should also be paid to that aspect and such files should contain the appropriate SPDX tag. 

Please note that I used the REUSE helper tool to add the headers, so the tool automatically deleted the existing header (if any) and changed it to the SPDX format.
#Image files in the .reuse directory in the root of the project:
Copyright and Licensing Information MAY be associated with a file through a DEP5 file that you will find in the .reuse folder in the root of the project. The intended use case of this method is large directories where including a comment header in each file (or in .license companion files) is impossible or undesirable. I added the GPL.v.02 only license to all of the image files. However, you can license other image files under licenses as well and include the license in the LICENSES directory.
We can also do a follow up of this PR and further REUSE specification with a call. Feel free to reach me out.

We can also do a follow up of this PR and further REUSE specification with a call. Feel free to reach me out. 

Hope that helps and thank you very much for the amazing job!

Niharika Singhal - Trainee
Free Software Foundation Europe
Schönhauser Allee 6/7, 10119 Berlin, Germany | t +49-30-27595290
Registered at Amtsgericht Hamburg, VR 17030 | https://fsfe.org/support