### PR TITLE
Fix VM sorting order in Qube Manager if Sorting by State and fix log browser

### DIFF
--- a/qubesmanager/log_dialog.py
+++ b/qubesmanager/log_dialog.py
@@ -45,8 +45,6 @@ class LogDialog(ui_logdlg.Ui_LogDialog, QtWidgets.QDialog):
 
         self.copy_to_qubes_clipboard.clicked.connect(
             self.copy_to_clipboard_triggered)
-        self.copy_to_qubes_clipboard.clicked.connect(
-            self.copy_to_clipboard_triggered)
 
         self.__init_log_text__()
 
@@ -63,7 +61,8 @@ class LogDialog(ui_logdlg.Ui_LogDialog, QtWidgets.QDialog):
         self.buttonsLayout.itemAt(0).widget().click()
 
     def copy_to_clipboard_triggered(self):
-        clipboard.copy_text_to_qubes_clipboard(self.displayed_text)
+        text = self.log_text.textCursor().selectedText() or self.displayed_text
+        clipboard.copy_text_to_qubes_clipboard(text)
 
     def set_current_log(self, log_path):
         self.displayed_text = ""

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -467,7 +467,18 @@ class QubesTableModel(QAbstractTableModel):
             if col_name == "Label":
                 return str(vm.label)
             if col_name == "State":
-                return str(vm.state)
+                # sorting order is based on a logical order (from running to
+                # progressively less running) and update state
+                state = vm.state.get('power', '')
+                try:
+                    ordered_state = str(
+                        ["Running", "Transient", "Halting", "Paused",
+                         "Suspended", "Dying", "Crashed",
+                         "Halted", "NA"].index(state))
+                except ValueError:
+                    ordered_state = state
+                updated = vm.state.get('outdated', '')
+                return ordered_state + updated
             if col_name == "Disk Usage":
                 return vm.disk_float
             return self.data(index, Qt.DisplayRole)

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -481,6 +481,9 @@ class QubesTableModel(QAbstractTableModel):
                 return ordered_state + updated
             if col_name == "Disk Usage":
                 return vm.disk_float
+            if col_name == "Backup":
+                # sort True before False, hence the not
+                return not vm.inc_backup
             return self.data(index, Qt.DisplayRole)
 
     # pylint: disable=invalid-name

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -465,7 +465,12 @@ class QubesTableModel(QAbstractTableModel):
             if col_name == "Type":
                 return vm.klass
             if col_name == "Label":
-                return str(vm.label)
+                vmtype, vmcolor = vm.icon.split("-")
+                try:
+                    processed_color = str(vm.label.index)
+                except ValueError:
+                    processed_color = vmcolor
+                return vmtype + processed_color
             if col_name == "State":
                 # sorting order is based on a logical order (from running to
                 # progressively less running) and update state


### PR DESCRIPTION
Previously the sorting order depended on alphabetically sorting the dictionary containing state, which was less than ideal. Now it will use a reasonable order (from more to less running, and within a given state, no updates come before updates-available).
Also fixes sorting the Backup column to actually use the include_in_backups state and the Label column to sort by label and type.

Also fixes the log browser to be selection-aware.

fixes QubesOS/qubes-issues#7073
fixes https://github.com/QubesOS/qubes-issues/issues/7633
fixes https://github.com/QubesOS/qubes-issues/issues/7776
fixes https://github.com/QubesOS/qubes-issues/issues/7715