### PR TITLE
Fix display of kernels for Qube Settings

### DIFF
--- a/qubesmanager/utils.py
+++ b/qubesmanager/utils.py
@@ -341,7 +341,7 @@ def initialize_widget_with_kernels(
     choices = [(kernel, kernel) for kernel in kernels]
 
     if allow_none:
-        choices.append((translate("(none)"), None))
+        choices.append((translate("(provided by qube)"), ''))
 
     initialize_widget_for_property(
         widget=widget, choices=choices, holder=holder,


### PR DESCRIPTION
After setting a vm.kernel to None, the property
vm.kernel outputted an empty string, not None object, which caused some funny problems with display of this property for Qube Settings (namely, we got a ' (current)' instead of a '(none) (current)'). This fixes this problem
and renames (none) to (provided by qube), because
that's what kernel = None should do.

fixes QubesOS/qubes-issues#7066