### PR TITLE
Allow saving backup settings without passphrase

### DIFF
--- a/qubesmanager/backup.py
+++ b/qubesmanager/backup.py
@@ -124,6 +124,12 @@ class BackupVMsWindow(ui_backupdlg.Ui_Backup, QtWidgets.QWizard):
         self.show_passwd_button.pressed.connect(self.show_password)
         self.show_passwd_button.released.connect(self.hide_password)
 
+        self.save_profile_checkbox.stateChanged.connect(
+            self.save_profile_changed)
+        self.save_passphrase_checkbox.stateChanged.connect(
+            self.save_profile_changed)
+        self.save_profile_changed()
+
         selected = self.vms_to_include()
         self.__fill_vms_list__(selected)
 
@@ -140,6 +146,12 @@ class BackupVMsWindow(ui_backupdlg.Ui_Backup, QtWidgets.QWizard):
     def hide_password(self):
         self.passphrase_line_edit.setEchoMode(QtWidgets.QLineEdit.Password)
         self.show_passwd_button.setIcon(QtGui.QIcon(':/eye-off.svg'))
+
+    def save_profile_changed(self):
+        save_profile = self.save_profile_checkbox.isChecked()
+        self.save_passphrase_checkbox.setEnabled(save_profile)
+        self.save_passphrase_warning.setEnabled(save_profile and
+                self.save_passphrase_checkbox.isChecked())
 
     def setup_application(self):
         self.qt_app.setApplicationName(self.tr("Qubes Backup VMs"))
@@ -202,11 +214,14 @@ class BackupVMsWindow(ui_backupdlg.Ui_Backup, QtWidgets.QWizard):
             self.passphrase_line_edit.setText(profile_data['passphrase_text'])
             self.passphrase_line_edit_verify.setText(
                 profile_data['passphrase_text'])
+            self.save_passphrase_checkbox.setChecked(True)
+        else:
+            self.save_passphrase_checkbox.setChecked(False)
 
         if 'compression' in profile_data:
             self.compress_checkbox.setChecked(profile_data['compression'])
 
-    def save_settings(self, use_temp):
+    def save_settings(self, use_temp, save_passphrase=True):
         """
         Helper function that saves backup profile to either
         /etc/qubes/backup/qubes-manager-backup.conf or
@@ -217,8 +232,10 @@ class BackupVMsWindow(ui_backupdlg.Ui_Backup, QtWidgets.QWizard):
         settings = {'destination_vm': self.appvm_combobox.currentText(),
                     'destination_path': self.dir_line_edit.text(),
                     'include': [vm.name for vm in self.selected_vms],
-                    'passphrase_text': self.passphrase_line_edit.text(),
                     'compression': self.compress_checkbox.isChecked()}
+
+        if save_passphrase:
+            settings['passphrase_text'] = self.passphrase_line_edit.text()
 
         backup_utils.write_backup_profile(settings, use_temp)
 
@@ -344,7 +361,9 @@ class BackupVMsWindow(ui_backupdlg.Ui_Backup, QtWidgets.QWizard):
         elif self.currentPage() is self.commit_page:
 
             if self.save_profile_checkbox.isChecked():
-                self.save_settings(use_temp=False)
+                save_passphrase = self.save_passphrase_checkbox.isChecked()
+                self.save_settings(use_temp=False,
+                   save_passphrase=save_passphrase)
 
             self.button(self.FinishButton).setDisabled(True)
             self.showFileDialog.setEnabled(

--- a/ui/backupdlg.ui
+++ b/ui/backupdlg.ui
@@ -221,8 +221,15 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="0" colspan="2">
-        <widget class="QLabel" name="label_9">
+       <item row="1" column="1">
+        <widget class="QCheckBox" name="save_passphrase_checkbox">
+         <property name="text">
+          <string>Save passphrase in backup profile</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QLabel" name="save_passphrase_warning">
          <property name="font">
           <font>
            <weight>75</weight>

--- a/ui/backupdlg.ui
+++ b/ui/backupdlg.ui
@@ -211,17 +211,10 @@
        <string>Save backup profile</string>
       </property>
       <layout class="QFormLayout" name="formLayout_3">
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_8">
-         <property name="text">
-          <string>Save settings as default backup profile:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
+       <item row="0" column="0" colspan="2">
         <widget class="QCheckBox" name="save_profile_checkbox">
          <property name="text">
-          <string/>
+          <string>Save settings as default backup profile</string>
          </property>
          <property name="checked">
           <bool>true</bool>
@@ -436,7 +429,6 @@ p, li { white-space: pre-wrap; }
   <tabstop>select_path_button</tabstop>
   <tabstop>passphrase_line_edit</tabstop>
   <tabstop>passphrase_line_edit_verify</tabstop>
-  <tabstop>save_profile_checkbox</tabstop>
   <tabstop>turn_off_checkbox</tabstop>
   <tabstop>textEdit</tabstop>
   <tabstop>showFileDialog</tabstop>

--- a/ui/backupdlg.ui
+++ b/ui/backupdlg.ui
@@ -436,9 +436,12 @@ p, li { white-space: pre-wrap; }
   <tabstop>select_path_button</tabstop>
   <tabstop>passphrase_line_edit</tabstop>
   <tabstop>passphrase_line_edit_verify</tabstop>
+  <tabstop>show_passwd_button</tabstop>
+  <tabstop>save_profile_checkbox</tabstop>
+  <tabstop>save_passphrase_checkbox</tabstop>
   <tabstop>turn_off_checkbox</tabstop>
-  <tabstop>textEdit</tabstop>
   <tabstop>showFileDialog</tabstop>
+  <tabstop>textEdit</tabstop>
  </tabstops>
  <resources>
   <include location="../resources.qrc"/>


### PR DESCRIPTION
This adds a separate "save passphrase in backup profile" checkbox, which is unchecked by default and gets saved in the profile (implicitly, with the presence of the password field). As a result, users may save their settings without having to compromise on the security of their passphrase.

The big fat warning about the passphrase getting saved like that is now grayed out when not applicable.

Fixes QubesOS/qubes-issues#4819

![image](https://user-images.githubusercontent.com/23580910/201431503-a574aea9-108a-4492-9ed1-a2dc53888067.png)
