### PR TITLE
Warn about metadata leaks in backups

### DIFF
--- a/qubesmanager/backup.py
+++ b/qubesmanager/backup.py
@@ -99,6 +99,8 @@ class BackupVMsWindow(ui_backupdlg.Ui_Backup, QtWidgets.QWizard):
         # but completeChanged twice. Somehow.
         self.select_vms_widget.selectedChanged.connect(
             self.select_vms_page.completeChanged.emit)
+        self.select_vms_widget.selectedChanged.connect(
+            self.update_metadata_warning)
         self.passphrase_line_edit.textChanged.connect(
             self.backup_location_changed)
         self.passphrase_line_edit_verify.textChanged.connect(
@@ -151,6 +153,10 @@ class BackupVMsWindow(ui_backupdlg.Ui_Backup, QtWidgets.QWizard):
         self.save_passphrase_checkbox.setEnabled(save_profile)
         self.save_passphrase_warning.setEnabled(save_profile and
                 self.save_passphrase_checkbox.isChecked())
+
+    def update_metadata_warning(self):
+        self.metadata_warning_label.setVisible(
+            self.select_vms_widget.available_list.count() > 0)
 
     def setup_application(self):
         self.qt_app.setApplicationName(self.tr("Qubes Backup VMs"))
@@ -279,6 +285,7 @@ class BackupVMsWindow(ui_backupdlg.Ui_Backup, QtWidgets.QWizard):
 
         self.total_size_label.setText(
             admin_utils.size_to_human(self.total_size))
+        self.update_metadata_warning()
 
     def vms_added(self, items):
         for i in items:

--- a/ui/backupdlg.ui
+++ b/ui/backupdlg.ui
@@ -91,6 +91,22 @@
      </widget>
     </item>
     <item>
+     <widget class="QLabel" name="metadata_warning_label">
+      <property name="font">
+       <font>
+        <weight>75</weight>
+        <bold>true</bold>
+       </font>
+      </property>
+      <property name="text">
+       <string>Warning: The backup will include metadata of all qubes, regardless of whether they are selected.</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
      <widget class="QLabel" name="unrecognized_config_label">
       <property name="palette">
        <palette>


### PR DESCRIPTION
Add a message to warn the user that a backup always includes metadata for all VMs on the system, to prevent e.g. leaking any sensitive qube names, should the filtered down backup get shared with somebody.

The message is not shown when all VMs are selected, to make it more noticeable when it could actually be relevant.

See also QubesOS/qubes-issues#2645

Further work: include similar precautions for the `qvm-create` CLI.