### PR TITLE
Fix detecting if widget was changed in VM settings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -17,12 +17,7 @@ ignore=tests,
 extension-pkg-whitelist=PyQt5
 
 [MESSAGES CONTROL]
-# abstract-class-little-used: see http://www.logilab.org/ticket/111138
-# deprecated-method:
-#   enable again after disabling py-3.4.3 asyncio.ensure_future compat hack
 disable=
-  abstract-class-little-used,
-  bad-continuation,
   cyclic-import,
   deprecated-method,
   duplicate-code,
@@ -30,11 +25,9 @@ disable=
   fixme,
   inconsistent-return-statements,
   locally-disabled,
-  locally-enabled,
   logging-format-interpolation,
   missing-docstring,
   consider-using-f-string,
-  star-args,
   useless-super-delegation,
   wrong-import-order
 

--- a/qubesmanager/clone_vm.py
+++ b/qubesmanager/clone_vm.py
@@ -50,7 +50,7 @@ class CloneVMDlg(QtWidgets.QDialog, Ui_CloneVMDlg):
         utils.initialize_widget_with_vms(
             widget=self.src_vm,
             qubes_app=self.app,
-            filter_function=(lambda vm: vm.klass != 'AdminVM'))
+            filter_function=lambda vm: vm.klass != 'AdminVM')
 
         if src_vm and self.src_vm.findText(src_vm.name) > -1:
             self.src_vm.setCurrentIndex(self.src_vm.findText(src_vm.name))

--- a/qubesmanager/firewall.py
+++ b/qubesmanager/firewall.py
@@ -190,7 +190,7 @@ class QubesFirewallRulesModel(QtCore.QAbstractItemModel):
         self.__children = None  # list of rules in the FW
 
     def sort(self, idx, order):
-        rev = (order == QtCore.Qt.AscendingOrder)
+        rev = order == QtCore.Qt.AscendingOrder
         self.children.sort(key=lambda x: self.get_column_string(idx, x),
                            reverse=rev)
 
@@ -294,7 +294,7 @@ class QubesFirewallRulesModel(QtCore.QAbstractItemModel):
 
             raise FirewallModifiedOutsideError(self.tr('it does not add up.'))
 
-        conf['allow'] = (common_action == 'accept')
+        conf['allow'] = common_action == 'accept'
 
         if not allow_icmp and not conf['allow']:
             raise FirewallModifiedOutsideError(self.tr('ICMP must be allowed.'))

--- a/qubesmanager/global_settings.py
+++ b/qubesmanager/global_settings.py
@@ -505,7 +505,7 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
         elif repos.get('qubes-dom0-current', {}).get('enabled', None):
             self.dom0_updates_repo.setCurrentIndex(0)
         else:
-            raise Exception(
+            raise exc.QubesException(
                 self.tr('Cannot detect enabled dom0 update repositories'))
 
         if repos.get('qubes-templates-itl-testing', {}).get('enabled', None):
@@ -513,8 +513,8 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
         elif repos.get('qubes-templates-itl', {}).get('enabled', None):
             self.itl_tmpl_updates_repo.setCurrentIndex(0)
         else:
-            raise Exception(self.tr('Cannot detect enabled ITL template update '
-                                    'repositories'))
+            raise exc.QubesException(self.tr('Cannot detect enabled ITL '
+                                             'template update repositories'))
 
         if repos.get(
                 'qubes-templates-community-testing', {}).get('enabled', None):

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -507,8 +507,8 @@ class QubesTableModel(QAbstractTableModel):
             col_name = self.columns_indices[index.column()]
             if col_name == "Backup":
                 vm = self.qubes_cache.get_vm(index.row())
-                vm.vm.include_in_backups = (value == Qt.Checked)
-                vm.inc_backup = (value == Qt.Checked)
+                vm.vm.include_in_backups = value == Qt.Checked
+                vm.inc_backup = value == Qt.Checked
                 return True
         return False
 

--- a/qubesmanager/qvm_template_gui.py
+++ b/qubesmanager/qvm_template_gui.py
@@ -134,7 +134,7 @@ class TemplateModel(PyQt5.QtCore.QAbstractItemModel):
         return super().flags(index)
 
     def sort(self, idx, order):
-        rev = (order == PyQt5.QtCore.Qt.AscendingOrder)
+        rev = order == PyQt5.QtCore.Qt.AscendingOrder
         self.children.sort(key=lambda x: x[idx], reverse=rev)
 
         self.dataChanged.emit(*self.row_index(0, self.rowCount() - 1))

--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -1240,7 +1240,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
                     self.vm.devices['pci'].detach(current_assignment)
 
                     current_assignment.options['no-strict-reset'] = \
-                        (dev.ident in self.new_strict_reset_list)
+                        dev.ident in self.new_strict_reset_list
 
                     self.vm.devices['pci'].attach(current_assignment)
 
@@ -1403,7 +1403,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
             for i in range(self.services_list.count()):
                 item = self.services_list.item(i)
                 self.new_srv_dict[str(item.text())] = \
-                    (item.checkState() == ui_settingsdlg.QtCore.Qt.Checked)
+                    item.checkState() == ui_settingsdlg.QtCore.Qt.Checked
 
             for service, v in self.new_srv_dict.items():
                 feature = SERVICE_PREFIX + service

--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -482,6 +482,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
         except qubesadmin.exc.QubesDaemonAccessError:
             self.autostart_vm.setEnabled(False)
         except AttributeError:
+            self.autostart_vm.setEnabled(False)
             self.autostart_vm.setVisible(False)
 
         # type
@@ -540,9 +541,8 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
 
         # vm label changed
         try:
-            if self.vmlabel.isVisible():
-                if utils.did_widget_selection_change(self.vmlabel):
-                    self.vm.label = self.vmlabel.currentData()
+            if utils.did_widget_selection_change(self.vmlabel):
+                self.vm.label = self.vmlabel.currentData()
         except qubesadmin.exc.QubesException as ex:
             msg.append(str(ex))
 
@@ -571,7 +571,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
 
         # autostart_vm
         try:
-            if self.autostart_vm.isVisible():
+            if self.autostart_vm.isEnabled():
                 if self.vm.autostart != self.autostart_vm.isChecked():
                     self.vm.autostart = self.autostart_vm.isChecked()
         except qubesadmin.exc.QubesException as ex:
@@ -827,7 +827,9 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
                 self.kernel_opts.setText(getattr(self.vm, 'kernelopts', '-'))
             except qubesadmin.exc.QubesDaemonAccessError:
                 self.kernel_groupbox.setVisible(False)
+                self.kernel.setEnabled(False)
         else:
+            self.kernel.setEnabled(False)
             self.kernel_groupbox.setVisible(False)
 
         if not hasattr(self.vm, 'default_dispvm'):
@@ -887,6 +889,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
             self.run_in_debug_mode.setVisible(True)
         except AttributeError:
             self.run_in_debug_mode.setVisible(False)
+            self.run_in_debug_mode.setEnabled(False)
 
         utils.initialize_widget(
             widget=self.allow_fullscreen,
@@ -958,7 +961,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
             msg.append(str(ex))
 
         # in case VM is not Linux
-        if hasattr(self.vm, "kernel") and self.kernel_groupbox.isVisible():
+        if hasattr(self.vm, "kernel"):
             try:
                 if utils.did_widget_selection_change(self.kernel):
                     self.vm.kernel = self.kernel.currentData()
@@ -999,7 +1002,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
 
         # run_in_debug_mode
         try:
-            if self.run_in_debug_mode.isVisible():
+            if self.run_in_debug_mode.isEnabled():
                 if self.vm.debug != self.run_in_debug_mode.isChecked():
                     self.vm.debug = self.run_in_debug_mode.isChecked()
         except qubesadmin.exc.QubesException as ex:


### PR DESCRIPTION
Instead of checking for isVisible, which can fail if we are on a different tab, check for isEnabled (also added appropriate disable commands where widget should be disabled).

fixes QubesOS/qubes-issues#7990