### PR TITLE
Make available/selected apps in settings clearer

### DIFF
--- a/qubesmanager/multiselectwidget.py
+++ b/qubesmanager/multiselectwidget.py
@@ -65,3 +65,8 @@ class MultiSelectWidget(
     def clear(self):
         self.available_list.clear()
         self.selected_list.clear()
+
+    def change_labels(self, available: str, selected: str):
+        """Set Available and Selected labels to provided text."""
+        self.selected_label.setText(selected)
+        self.available_label.setText(available)

--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -220,6 +220,9 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
         ####### apps tab
         if self.tabWidget.isTabEnabled(self.tabs_indices["applications"]):
             self.app_list = multiselectwidget.MultiSelectWidget(self)
+            self.app_list.change_labels(
+                available="All available applications",
+                selected="Applications shown in App Menu")
             self.apps_layout.addWidget(self.app_list)
             self.app_list_manager = AppmenuSelectManager(self.vm, self.app_list)
             self.refresh_apps_button.clicked.connect(
@@ -1150,6 +1153,9 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
     ######## devices tab
     def __init_devices_tab__(self):
         self.dev_list = multiselectwidget.MultiSelectWidget(self)
+        self.dev_list.change_labels(
+            available="Available devices",
+            selected="Devices always connected to this qube")
         self.dev_list.add_all_button.setVisible(False)
         self.devices_layout.addWidget(self.dev_list)
 

--- a/ui/multiselectwidget.ui
+++ b/ui/multiselectwidget.ui
@@ -48,7 +48,7 @@
         </spacer>
        </item>
        <item>
-        <widget class="QLabel" name="label">
+        <widget class="QLabel" name="available_label">
          <property name="text">
           <string>Available</string>
          </property>
@@ -150,7 +150,7 @@
         </spacer>
        </item>
        <item>
-        <widget class="QLabel" name="label_2">
+        <widget class="QLabel" name="selected_label">
          <property name="text">
           <string>Selected</string>
          </property>


### PR DESCRIPTION
Replace Available/Selected with a more explicit
"Available in qube/template" and "Shown in App Menu"

fixes https://github.com/QubesOS/qubes-issues/issues/8012

based on https://github.com/QubesOS/qubes-manager/pull/335 to avoid cherrypicking the pylint fixes back and forth.