### PR TITLE
Catch more exceptions

### DIFF
--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -637,7 +637,7 @@ class UpdateVMThread(common_threads.QubesThread):
                         pass
                 self.vm.run_service("qubes.InstallUpdatesGUI",
                                     user="root", wait=False)
-        except (ChildProcessError, subprocess.CalledProcessError,
+        except (OSError, subprocess.SubprocessError,
                 exc.QubesException) as ex:
             self.msg = (self.tr("Error on qube update!"), str(ex))
 


### PR DESCRIPTION
run_service() can raise FileNotFoundError, so catch OSError and all of its subclasses.  Also catch the more general subprocess.SubprocessError instead of just subprocess.CalledProcessError.

Fixes: QubesOS/qubes-issues#8151