### PR TITLE
Preliminary GUI initiated QWT install

### DIFF
--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -1414,7 +1414,9 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
                     self.tr("QWT not found"),
                     self.tr("'qubes-windows-tools' is not installed in dom0."))
         for vm_info in self.get_selected_vms():
-            qvm_start.main(['--cdrom', 'dom0:/usr/lib/qubes/qubes-windows-tools.iso', vm_info.vm.name])
+            vm = vm_info.vm
+            qvm_start.main(['--cdrom', 
+                'dom0:/usr/lib/qubes/qubes-windows-tools.iso', vm.name])
 
     @pyqtSlot(name='on_action_pausevm_triggered')
     def action_pausevm_triggered(self):

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -1405,9 +1405,14 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
 
     # noinspection PyArgumentList
     @pyqtSlot(name='on_action_startvm_tools_install_triggered')
-    # TODO: error handling
+    # TODO: unhardcode path
     def action_startvm_tools_install_triggered(self):
         # pylint: disable=invalid-name
+        if not path.exists(r'/usr/lib/qubes/qubes-windows-tools.iso'):
+            QMessageBox.warning(
+                    self,
+                    self.tr("QWT not found"),
+                    self.tr("'qubes-windows-tools' is not installed in dom0."))
         for vm_info in self.get_selected_vms():
             qvm_start.main(['--cdrom', 'dom0:/usr/lib/qubes/qubes-windows-tools.iso', vm_info.vm.name])
 

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -28,6 +28,7 @@ from os import path
 
 from qubesadmin import exc
 from qubesadmin import utils
+from qubesadmin.tools import qvm_start
 
 # pylint: disable=import-error
 from PyQt5.QtCore import (Qt, QAbstractTableModel, QObject, pyqtSlot, QEvent,
@@ -1404,10 +1405,11 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
 
     # noinspection PyArgumentList
     @pyqtSlot(name='on_action_startvm_tools_install_triggered')
-    # TODO: replace with boot from device
+    # TODO: error handling
     def action_startvm_tools_install_triggered(self):
         # pylint: disable=invalid-name
-        pass
+        for vm_info in self.get_selected_vms():
+            qvm_start.main(['--cdrom', 'dom0:/usr/lib/qubes/qubes-windows-tools.iso', vm_info.vm.name])
 
     @pyqtSlot(name='on_action_pausevm_triggered')
     def action_pausevm_triggered(self):

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -1415,7 +1415,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
                     self.tr("'qubes-windows-tools' is not installed in dom0."))
         for vm_info in self.get_selected_vms():
             vm = vm_info.vm
-            qvm_start.main(['--cdrom', 
+            qvm_start.main(['--cdrom',
                 'dom0:/usr/lib/qubes/qubes-windows-tools.iso', vm.name])
 
     @pyqtSlot(name='on_action_pausevm_triggered')


### PR DESCRIPTION
Simple modification.

~~Current limitations: If there's no QWT installed, this will silently fail ( the same as previously ). However, qvm-start will leave a humble line in the journal.~~

~~I thought of using os.path.exist() to detect if there's qwt image, but I'm not sure how to correctly implement it.~~

Current limitations: Path is hardcoded, and I think it will work awkwardly in sys-gui.