### PR TITLE
Check if default_netvm is running when changing netvm

### DIFF
--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -871,7 +871,6 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
                 QMessageBox.warning(self, self.tr("{0} template change failed!")
                         .format(error[0]), error[1])
 
-
     def change_network(self, netvm_name):
         selected_vms = self.get_selected_vms()
         reply = QMessageBox.question(
@@ -884,10 +883,13 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
         if reply != QMessageBox.Yes:
             return
 
-        if netvm_name not in [None, 'default']:
+        if netvm_name:
             check_power = any(info.state['power'] == 'Running' for info
                     in self.get_selected_vms())
-            netvm = self.qubes_cache.get_vm(name=netvm_name)
+            if netvm_name == 'default':
+                netvm = self._get_default_netvm()
+            else:
+                netvm = self.qubes_cache.get_vm(name=netvm_name)
             if check_power and netvm.state['power'] != 'Running':
                 reply = QMessageBox.question(
                     self, self.tr("Qube Start Confirmation"),

--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -562,7 +562,26 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
         # vm netvm changed
         try:
             if utils.did_widget_selection_change(self.netVM):
-                self.vm.netvm = self.netVM.currentData()
+                if self.netVM.currentData() == qubesadmin.DEFAULT:
+                    netvm = self.vm.property_get_default('netvm')
+                else:
+                    netvm = self.netVM.currentData()
+                if self.vm.get_power_state() == 'Running' and netvm and \
+                        netvm.get_power_state() != 'Running':
+                    reply = QtWidgets.QMessageBox.question(
+                        self, self.tr("Qube Start Confirmation"),
+                        self.tr("<br>Can not change netvm of a running qube"
+                                "to a halted Qube.<br>"
+                                "Do you want to start the Qube"
+                                " <b>'{0}'</b>?").format(netvm.name),
+                        QtWidgets.QMessageBox.Yes |
+                        QtWidgets.QMessageBox.Cancel)
+
+                    if reply == QtWidgets.QMessageBox.Yes:
+                        netvm.start()
+                        self.vm.netvm = self.netVM.currentData()
+                else:
+                    self.vm.netvm = self.netVM.currentData()
         except qubesadmin.exc.QubesException as ex:
             msg.append(str(ex))
 


### PR DESCRIPTION
Changing netvm checks if new netvm is running, and if not asks to start it - this didn't happen for default netvm. Now it will.

fixes QubesOS/qubes-issues#8156