### PR TITLE
tests: fix vm settings tests with 'default-dvm' DispVM

### DIFF
--- a/qubesmanager/tests/test_vm_settings.py
+++ b/qubesmanager/tests/test_vm_settings.py
@@ -580,7 +580,7 @@ class VMSettingsTest(unittest.TestCase):
             self.skipTest("not enough choices for " + widget.objectName())
 
         widget.setCurrentIndex(0)
-        while "default" not in widget.currentText():
+        while "default " not in widget.currentText():
             widget.setCurrentIndex(widget.currentIndex() + 1)
 
         return widget.currentText()


### PR DESCRIPTION
Now looking just for "default" is not enough, as now it's also part of a
VM name. Add a space which cannot be part of a normal VM.