### PR TITLE
Show Global Settings even if no dom0 updates are enabled

### DIFF
--- a/qubesmanager/global_settings.py
+++ b/qubesmanager/global_settings.py
@@ -479,16 +479,14 @@ class GlobalSettingsWindow(ui_globalsettingsdlg.Ui_GlobalSettings,
         elif repos.get('qubes-dom0-current', {}).get('enabled', None):
             self.dom0_updates_repo.setCurrentIndex(0)
         else:
-            raise exc.QubesException(
-                self.tr('Cannot detect enabled dom0 update repositories'))
+            self.dom0_updates_repo.setEnabled(False)
 
         if repos.get('qubes-templates-itl-testing', {}).get('enabled', None):
             self.itl_tmpl_updates_repo.setCurrentIndex(1)
         elif repos.get('qubes-templates-itl', {}).get('enabled', None):
             self.itl_tmpl_updates_repo.setCurrentIndex(0)
         else:
-            raise exc.QubesException(self.tr('Cannot detect enabled ITL '
-                                             'template update repositories'))
+            self.itl_tmpl_updates_repo.setEnabled(False)
 
         if repos.get(
                 'qubes-templates-community-testing', {}).get('enabled', None):


### PR DESCRIPTION
dom0 update dropdown will be disabled, but the
window will be shown.

fixes QubesOS/qubes-issues#8469