### PR TITLE
Fix minor bug and improve qube manager imports

### DIFF
--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -47,15 +47,15 @@ from PyQt5.QtGui import (QIcon, QPixmap, QRegExpValidator, QFont, QColor,
 
 from qubesmanager.about import AboutDialog
 
-from . import ui_qubemanager  # pylint: disable=no-name-in-module
-from . import settings
-from . import restore
-from . import backup
-from . import create_new_vm
-from . import log_dialog
-from . import utils as manager_utils
-from . import common_threads
-from . import clone_vm
+from qubesmanager import ui_qubemanager  # pylint: disable=no-name-in-module
+from qubesmanager import settings
+from qubesmanager import restore
+from qubesmanager import backup
+from qubesmanager import create_new_vm
+from qubesmanager import log_dialog
+from qubesmanager import utils as manager_utils
+from qubesmanager import common_threads
+from qubesmanager import clone_vm
 
 
 def spawn_in_background(cmd: str | list[str]) -> None:

--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -1461,9 +1461,9 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
         self.set_allow(model.allow)
         if model.temp_full_access_expire_time:
             self.temp_full_access.setChecked(True)
-            self.temp_full_access_time.setValue(
-                (model.temp_full_access_expire_time -
-                 int(firewall.datetime.datetime.now().strftime("%s"))) / 60)
+            expire_time = model.temp_full_access_expire_time - \
+                          firewall.datetime.datetime.now().strftime("%s")
+            self.temp_full_access_time.setValue(int(expire_time / 60))
 
     def disable_all_fw_conf(self):
         self.firewall_modified_outside_label.setVisible(True)


### PR DESCRIPTION
- Remove relative imports from qubesmanager
This is a mostly-cosmetic change, but enables running manager in-vm using mocks.

- Fix broken VM settings for a VM with temporary unlocked FW