### PR TITLE
Enabling drag and drop between application lists

### DIFF
--- a/qubesmanager/appmenu_select.py
+++ b/qubesmanager/appmenu_select.py
@@ -36,6 +36,8 @@ class AppListWidgetItem(QtWidgets.QListWidgetItem):
             tooltip += "\n" + additional_description
         self.setToolTip(tooltip)
         self.ident = ident
+        # Using identity as tooltip which also enables drag-and-drop
+        self.setWhatsThis(ident)
 
     @classmethod
     def from_line(cls, line):

--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -231,6 +231,22 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
             self.refresh_apps_button.clicked.connect(
                 self.refresh_apps_button_pressed)
 
+            # Enable Drag & Drop between between two panels
+            # ToDo: Disable D&D between multiple instances of qubes-vm-settings
+            # - by overriding QListWidget.dragMoveEvent event
+            self.app_list.available_list.setDragEnabled(True)
+            self.app_list.available_list.setAcceptDrops(True)
+            self.app_list.available_list.setDragDropMode(
+                QtWidgets.QListWidget.DragDrop)
+            self.app_list.available_list.setDefaultDropAction(
+                QtCore.Qt.MoveAction)
+            self.app_list.selected_list.setDragEnabled(True)
+            self.app_list.selected_list.setAcceptDrops(True)
+            self.app_list.selected_list.setDragDropMode(
+                QtWidgets.QListWidget.DragDrop)
+            self.app_list.selected_list.setDefaultDropAction(
+                QtCore.Qt.MoveAction)
+
             # template change
             if self.template_name.isEnabled():
                 self.template_name.currentIndexChanged.connect(


### PR DESCRIPTION
Follow-up to issue https://github.com/QubesOS/qubes-issues/issues/8836

To give users more choices to move applications between available and selected app lists