### PR TITLE
clone_vm: Don't use warning MessageBox on success

### DIFF
--- a/qubesmanager/clone_vm.py
+++ b/qubesmanager/clone_vm.py
@@ -143,7 +143,7 @@ class CloneVMDlg(QtWidgets.QDialog, Ui_CloneVMDlg):
                 self.tr("ERROR: {0}").format(self.thread.msg))
         else:
             (title, msg) = self.thread.msg
-            QtWidgets.QMessageBox.warning(
+            QtWidgets.QMessageBox.information(
                 self,
                 title,
                 msg)


### PR DESCRIPTION
QMessageBox.warning shows a scary exclamation mark, which is confusing when reporting success. Use QMessageBox.information instead.

Reported-by: Rafał Wojdyła <omeg@invisiblethingslab.com>