### PR TITLE
Adjust for pylint too-many-positional-arguments

### DIFF
--- a/qubesmanager/bootfromdevice.py
+++ b/qubesmanager/bootfromdevice.py
@@ -29,7 +29,7 @@ from qubesadmin.tools import qvm_start
 
 class VMBootFromDeviceWindow(ui_bootfromdevice.Ui_BootDialog,
                              QtWidgets.QDialog):
-    def __init__(self, vm, qapp, qubesapp=None, parent=None, new_vm=False):
+    def __init__(self, vm, qapp, qubesapp=None, parent=None, *, new_vm=False):
         super().__init__(parent)
 
         self.vm = vm

--- a/qubesmanager/create_new_vm.py
+++ b/qubesmanager/create_new_vm.py
@@ -39,6 +39,7 @@ from .ui_newappvmdlg import Ui_NewVMDlg  # pylint: disable=import-error
 
 # pylint: disable=too-few-public-methods
 class CreateVMThread(QtCore.QThread):
+    # pylint: disable=too-many-positional-arguments
     def __init__(self, app, vmclass, name, label, template, properties,
                  pool):
         QtCore.QThread.__init__(self)
@@ -181,7 +182,7 @@ class NewVmDlg(QtWidgets.QDialog, Ui_NewVMDlg):
 
         if self.install_system.isChecked():
             self.boot_dialog = bootfromdevice.VMBootFromDeviceWindow(
-                name, self.qtapp, self.app, self, True)
+                name, self.qtapp, self.app, self, new_vm=True)
             if not self.boot_dialog.exec_():
                 return
 
@@ -222,7 +223,14 @@ class NewVmDlg(QtWidgets.QDialog, Ui_NewVMDlg):
             properties['memory'] = self.init_ram.value()
 
         self.thread = CreateVMThread(
-            self.app, vmclass, name, label, template, properties, pool)
+            app=self.app,
+            vmclass=vmclass,
+            name=name,
+            label=label,
+            template=template,
+            properties=properties,
+            pool=pool
+        )
         self.thread.finished.connect(self.create_finished)
         self.thread.start()
 

--- a/qubesmanager/device_list.py
+++ b/qubesmanager/device_list.py
@@ -22,7 +22,8 @@ from PyQt5 import QtWidgets  # pylint: disable=import-error
 
 
 class PCIDeviceListWindow(ui_devicelist.Ui_Dialog, QtWidgets.QDialog):
-    def __init__(self, vm, qapp, dev_list, no_strict_reset_list, parent=None):
+    def __init__(self, vm, qapp, dev_list, no_strict_reset_list, *,
+            parent=None):
         super().__init__(parent)
 
         self.vm = vm

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -1603,7 +1603,8 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
         try:
             with common_threads.busy_cursor():
                 settings_window = settings.VMSettingsWindow(
-                    vm, tab, self.qt_app, self.qubes_app, self)
+                    vm, tab, self.qt_app, self.qubes_app,
+                    parent=self)
             settings_window.show()
             self.settings_windows[vm.name] = settings_window
         except exc.QubesException as ex:

--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -138,7 +138,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
         ('services', 5),
         ))
 
-    def __init__(self, vm, init_page="basic", qapp=None, qubesapp=None,
+    def __init__(self, vm, init_page="basic", qapp=None, qubesapp=None, *,
                  parent=None):
         super().__init__(parent)
 
@@ -1342,7 +1342,10 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
 
     def strict_reset_button_pressed(self):
         device_list_window = device_list.PCIDeviceListWindow(
-            self.vm, self.qapp, self.dev_list, self.new_strict_reset_list, self)
+            self.vm, self.qapp,
+            dev_list=self.dev_list,
+            no_strict_reset_list=self.new_strict_reset_list,
+            parent=self)
         device_list_window.exec()
 
     ######## applications tab

--- a/qubesmanager/template_manager.py
+++ b/qubesmanager/template_manager.py
@@ -316,7 +316,7 @@ class NewTemplateItem(QtWidgets.QComboBox):
 
 
 class VMRow:
-    # pylint: disable=too-few-public-methods
+    # pylint: disable=too-few-public-methods,too-many-positional-arguments
     def __init__(self, vm, row_no, table_widget, columns, templates):
         self.vm = vm
         self.table_widget = table_widget

--- a/qubesmanager/tests/test_create_new_vm.py
+++ b/qubesmanager/tests/test_create_new_vm.py
@@ -65,9 +65,9 @@ class NewVmTest(unittest.TestCase):
         self.__click_ok()
 
         self.mock_thread.assert_called_once_with(
-            self.qapp, "AppVM", "test-vm",
-            unittest.mock.ANY, self.qapp.default_template,
-            {'provides_network': False}, unittest.mock.ANY)
+            app=self.qapp, vmclass="AppVM", name="test-vm",
+            label=unittest.mock.ANY, template=self.qapp.default_template,
+            properties={'provides_network': False}, pool=unittest.mock.ANY)
         self.mock_thread().start.assert_called_once_with()
 
     def test_03_label(self):
@@ -80,9 +80,9 @@ class NewVmTest(unittest.TestCase):
         self.__click_ok()
 
         self.mock_thread.assert_called_once_with(
-            self.qapp, "AppVM", "test-vm",
-            self.qapp.labels['blue'], self.qapp.default_template,
-            unittest.mock.ANY, unittest.mock.ANY)
+            app=self.qapp, vmclass="AppVM", name="test-vm",
+            label=self.qapp.labels['blue'], template=self.qapp.default_template,
+            properties=unittest.mock.ANY, pool=unittest.mock.ANY)
         self.mock_thread().start.assert_called_once_with()
 
     def test_04_template(self):
@@ -97,9 +97,9 @@ class NewVmTest(unittest.TestCase):
         self.__click_ok()
 
         self.mock_thread.assert_called_once_with(
-            self.qapp, "AppVM", "test-vm",
-            unittest.mock.ANY, template,
-            unittest.mock.ANY, unittest.mock.ANY)
+            app=self.qapp, vmclass="AppVM", name="test-vm",
+            label=unittest.mock.ANY, template=template,
+            properties=unittest.mock.ANY, pool=unittest.mock.ANY)
 
     def test_05_netvm(self):
         netvm = None
@@ -113,9 +113,10 @@ class NewVmTest(unittest.TestCase):
         self.__click_ok()
 
         self.mock_thread.assert_called_once_with(
-            self.qapp, "AppVM", "test-vm",
-            unittest.mock.ANY, unittest.mock.ANY,
-            {'netvm': netvm, 'provides_network': False}, unittest.mock.ANY)
+            app=self.qapp, vmclass="AppVM", name="test-vm",
+            label=unittest.mock.ANY, template=unittest.mock.ANY,
+            properties={'netvm': netvm, 'provides_network': False},
+            pool=unittest.mock.ANY)
 
     def test_06_provides_network(self):
         self.dialog.provides_network.setChecked(True)
@@ -124,9 +125,9 @@ class NewVmTest(unittest.TestCase):
         self.__click_ok()
 
         self.mock_thread.assert_called_once_with(
-            self.qapp, "AppVM", "test-vm",
-            unittest.mock.ANY, unittest.mock.ANY,
-            {'provides_network': True}, unittest.mock.ANY)
+            app=self.qapp, vmclass="AppVM", name="test-vm",
+            label=unittest.mock.ANY, template=unittest.mock.ANY,
+            properties={'provides_network': True}, pool=unittest.mock.ANY)
 
     @unittest.mock.patch('subprocess.check_call')
     def test_07_launch_settings(self, mock_call):
@@ -138,9 +139,9 @@ class NewVmTest(unittest.TestCase):
 
         # make sure the thread is not reporting an error
         self.mock_thread.assert_called_once_with(
-            self.qapp, "AppVM", "test-vm",
-            unittest.mock.ANY, unittest.mock.ANY,
-            unittest.mock.ANY, unittest.mock.ANY)
+            app=self.qapp, vmclass="AppVM", name="test-vm",
+            label=unittest.mock.ANY, template=unittest.mock.ANY,
+            properties=unittest.mock.ANY, pool=unittest.mock.ANY)
 
         self.mock_thread().msg = None
         self.dialog.create_finished()
@@ -153,9 +154,9 @@ class NewVmTest(unittest.TestCase):
         self.__click_ok()
 
         self.mock_thread.assert_called_once_with(
-            self.qapp, "AppVM", "test-vm",
-            unittest.mock.ANY, unittest.mock.ANY,
-            unittest.mock.ANY, unittest.mock.ANY)
+            app=self.qapp, vmclass="AppVM", name="test-vm",
+            label=unittest.mock.ANY, template=unittest.mock.ANY,
+            properties=unittest.mock.ANY, pool=unittest.mock.ANY)
 
         # make sure the thread is not reporting an error
         self.mock_thread().start.assert_called_once_with()
@@ -177,9 +178,9 @@ class NewVmTest(unittest.TestCase):
 
         self.__click_ok()
         self.mock_thread.assert_called_once_with(
-            self.qapp, "StandaloneVM", "test-vm",
-            unittest.mock.ANY, unittest.mock.ANY,
-            unittest.mock.ANY, unittest.mock.ANY)
+            app=self.qapp, vmclass="StandaloneVM", name="test-vm",
+            label=unittest.mock.ANY, template=unittest.mock.ANY,
+            properties=unittest.mock.ANY, pool=unittest.mock.ANY)
 
     @unittest.mock.patch('qubesmanager.bootfromdevice.VMBootFromDeviceWindow')
     @unittest.mock.patch('qubesadmin.tools.qvm_start')
@@ -197,9 +198,9 @@ class NewVmTest(unittest.TestCase):
 
         self.__click_ok()
         self.mock_thread.assert_called_once_with(
-            self.qapp, "StandaloneVM", "test-vm",
-            unittest.mock.ANY, None,
-            unittest.mock.ANY, unittest.mock.ANY)
+            app=self.qapp, vmclass="StandaloneVM", name="test-vm",
+            label=unittest.mock.ANY, template=None,
+            properties=unittest.mock.ANY, pool=unittest.mock.ANY)
 
         self.mock_thread().msg = None
         self.dialog.create_finished()
@@ -224,9 +225,9 @@ class NewVmTest(unittest.TestCase):
 
         self.__click_ok()
         self.mock_thread.assert_called_once_with(
-            self.qapp, "StandaloneVM", "test-vm",
-            unittest.mock.ANY, None,
-            unittest.mock.ANY, unittest.mock.ANY)
+            app=self.qapp, vmclass="StandaloneVM", name="test-vm",
+            label=unittest.mock.ANY, template=None,
+            properties=unittest.mock.ANY, pool=unittest.mock.ANY)
 
         self.mock_thread().msg = None
         self.dialog.create_finished()

--- a/qubesmanager/tests/test_qube_manager.py
+++ b/qubesmanager/tests/test_qube_manager.py
@@ -1152,6 +1152,8 @@ class QubeManagerTest(unittest.TestCase):
         vm_row = self._find_vm_row(target_vm_name)
 
         old_netvm = self._get_table_item(vm_row, "NetVM")
+        # in case of "default (...)" take "default"
+        old_newvm = old_netvm.split(' ')[0]
         new_netvm = None
         for vm in self.qapp.domains:
             if getattr(vm, "provides_network", False) and vm.name != old_netvm:

--- a/qubesmanager/tests/test_qube_manager.py
+++ b/qubesmanager/tests/test_qube_manager.py
@@ -177,7 +177,7 @@ class QubeManagerTest(unittest.TestCase):
             ip_item = self._get_table_item(row, "IP Address")
             if hasattr(vm, 'ip'):
                 ip_value = getattr(vm, 'ip')
-                ip_value = "" if ip_value is None else ip_value
+                ip_value = "n/a" if not ip_value else ip_value
             else:
                 ip_value = "n/a"
 

--- a/qubesmanager/tests/test_qube_manager.py
+++ b/qubesmanager/tests/test_qube_manager.py
@@ -304,7 +304,7 @@ class QubeManagerTest(unittest.TestCase):
         QtTest.QTest.mouseClick(widget,
                                 QtCore.Qt.LeftButton)
         mock_window.assert_called_once_with(
-            selected_vm, "basic", self.qtapp, self.qapp, self.dialog)
+            selected_vm, "basic", self.qtapp, self.qapp, parent=self.dialog)
 
     def test_201_vm_open_settings_admin(self):
         self._select_admin_vm()
@@ -325,7 +325,7 @@ class QubeManagerTest(unittest.TestCase):
         QtTest.QTest.mouseClick(widget,
                                 QtCore.Qt.LeftButton)
         mock_window.assert_called_once_with(
-            selected_vm, "firewall", self.qtapp, self.qapp, self.dialog)
+            selected_vm, "firewall", self.qtapp, self.qapp, parent=self.dialog)
 
     @unittest.mock.patch('qubesmanager.settings.VMSettingsWindow')
     def test_203_vm_open_apps(self, mock_window):
@@ -336,7 +336,8 @@ class QubeManagerTest(unittest.TestCase):
         QtTest.QTest.mouseClick(widget,
                                 QtCore.Qt.LeftButton)
         mock_window.assert_called_once_with(
-            selected_vm, "applications", self.qtapp, self.qapp, self.dialog)
+            selected_vm, "applications", self.qtapp, self.qapp,
+            parent=self.dialog)
 
     @unittest.mock.patch('PyQt5.QtWidgets.QMessageBox.warning')
     def test_204_vm_keyboard(self, mock_message):
@@ -1028,7 +1029,7 @@ class QubeManagerTest(unittest.TestCase):
             self.dialog.action_settings.trigger()
             mock_settings.assert_called_once_with(
                 self.qapp.domains["test-vm"], "basic",
-                self.qtapp, self.qapp, self.dialog)
+                self.qtapp, self.qapp, parent=self.dialog)
 
     def test_401_event_domain_removed(self):
         initial_vms = self._create_set_of_current_vms()

--- a/qubesmanager/utils.py
+++ b/qubesmanager/utils.py
@@ -198,7 +198,7 @@ def initialize_widget(widget, choices, selected_value=None,
 
 
 def initialize_widget_for_property(
-        widget, choices, holder, property_name, allow_default=False,
+        widget, choices, holder, property_name, *, allow_default=False,
         icon_getter=None, add_current_label=True):
     """
     populates widget (ListBox or ComboBox) with items, based on a listed
@@ -248,7 +248,7 @@ def initialize_widget_for_property(
 
 # TODO: improvement: add optional icon support
 def initialize_widget_with_vms(
-        widget, qubes_app, filter_function=(lambda x: True),
+        widget, qubes_app, *, filter_function=(lambda x: True),
         allow_none=False, holder=None, property_name=None,
         allow_default=False, allow_internal=False):
     """
@@ -292,7 +292,7 @@ def initialize_widget_with_vms(
 
 
 def initialize_widget_with_default(
-        widget, choices, add_none=False, add_qubes_default=False,
+        widget, choices, *, add_none=False, add_qubes_default=False,
         mark_existing_as_default=False, default_value=None):
     """
     populates widget (ListBox or ComboBox) with items. Used when there is no
@@ -352,7 +352,7 @@ def initialize_widget_with_default(
 
 
 def initialize_widget_with_kernels(
-        widget, qubes_app, allow_none=False, holder=None,
+        widget, qubes_app, *, allow_none=False, holder=None,
         property_name=None, allow_default=False):
     """
     populates widget (ListBox or ComboBox) with kernel items, based on a given


### PR DESCRIPTION
Use keyword-only args where it makes sense (most places, to improve
readability), and ignore in others.