### PR TITLE
Open global config from template gui at correct location

### DIFF
--- a/qubesmanager/qvm_template_gui.py
+++ b/qubesmanager/qvm_template_gui.py
@@ -704,7 +704,8 @@ class QvmTemplateWindow(
         """
         Run global config in foreground (blocking)
         """
-        subprocess.call('qubes-global-config')
+        subprocess.call(
+            ['qubes-global-config', '-o', 'updates#template_repositories'])
         self.refresh()
 
     def _get_selected_item(self) -> typing.Optional[TreeItem]:


### PR DESCRIPTION
When opening template repo settings, open at those template repo settings, and not at the "General" page.

fixes QubesOS/qubes-issues#9530
requires https://github.com/QubesOS/qubes-desktop-linux-manager/pull/227