### PR TITLE
Add boot mode support

### DIFF
--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -933,19 +933,6 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
                     default_text_provider=get_default_bootmode_name
                 )
                 if hasattr(self.vm, "appvm_default_bootmode"):
-                    # We need to recreate the bootmode_widget_data list,
-                    # because utils.initialize_widget_for_property adds a
-                    # default item to the list as a side-effect, and we'd end
-                    # up with duplicate "default" entries if we didn't
-                    # reinitialize it. Modifying
-                    # initialize_widget_for_property to operate on a list deep
-                    # copy breaks the virtualization mode combo box, making
-                    # the default mode appear as
-                    # `<object object at 0xaddress>`.
-                    bootmode_widget_data = list(zip(
-                        self.bootmode_names, self.bootmode_ids
-                    ))
-                    bootmode_widget_data.sort()
                     utils.initialize_widget_for_property(
                         widget=self.appvm_default_bootmode,
                         choices=bootmode_widget_data,

--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -63,6 +63,16 @@ INTERNAL_SERVICE_FEATURES = [IDLE_SERVICE]
 INTERNAL_SUPPORTED_FEATURES = [IDLE_SUPPORTED_SERVICE]
 
 
+def get_default_bootmode_name(vm, bootmode):
+    if bootmode == "default":
+        return vm.features.check_with_template(
+            "boot-mode.name.default", ""
+        )
+    return vm.features.check_with_template(
+        f"boot-mode.name.{bootmode}", bootmode
+    )
+
+
 # pylint: disable=too-few-public-methods
 class RenameVMThread(common_threads.QubesThread):
     def __init__(self, vm, new_vm_name, dependencies):
@@ -392,6 +402,25 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
 
         self.netvm_no_firewall_label.setVisible(no_firewall_state)
         self.sysnet_warning_label.setVisible(netvm is None and provides_network)
+
+    def collect_bootmode_data(self):
+        bootmode_ids = [
+            x.split('.')[2] for x in self.vm.features \
+                if x.startswith("boot-mode.kernelopts.")
+        ]
+        subject = self.vm
+        while hasattr(subject, "template"):
+            bootmode_ids.extend([
+                x.split('.')[2] for x in subject.template.features \
+                    if x.startswith("boot-mode.kernelopts.")
+            ])
+            subject = subject.template
+        bootmode_names = [
+            self.vm.features.check_with_template(
+                f"boot-mode.name.{x}", x
+            ) for x in bootmode_ids
+        ]
+        return bootmode_names, bootmode_ids
 
     def current_tab_changed(self, idx):
         if idx == self.tabs_indices["firewall"]:
@@ -882,6 +911,59 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
                     property_name='kernel')
                 self.kernel.currentIndexChanged.connect(self.kernel_changed)
                 self.kernel_opts.setText(getattr(self.vm, 'kernelopts', '-'))
+                # load bootmode information from features
+                if hasattr(self.vm, "appvm_default_bootmode"):
+                    self.appvm_default_bootmode_desc.setVisible(True)
+                    self.appvm_default_bootmode.setVisible(True)
+                else:
+                    self.appvm_default_bootmode_desc.setVisible(False)
+                    self.appvm_default_bootmode.setVisible(False)
+                self.bootmode_names, self.bootmode_ids \
+                    = self.collect_bootmode_data()
+                bootmode_widget_data = list(zip(
+                    self.bootmode_names, self.bootmode_ids
+                ))
+                bootmode_widget_data.sort()
+                utils.initialize_widget_for_property(
+                    widget=self.bootmode,
+                    choices=bootmode_widget_data,
+                    property_name="bootmode",
+                    holder=self.vm,
+                    allow_default=True,
+                    default_text_provider=get_default_bootmode_name
+                )
+                if hasattr(self.vm, "appvm_default_bootmode"):
+                    # We need to recreate the bootmode_widget_data list,
+                    # because utils.initialize_widget_for_property adds a
+                    # default item to the list as a side-effect, and we'd end
+                    # up with duplicate "default" entries if we didn't
+                    # reinitialize it. Modifying
+                    # initialize_widget_for_property to operate on a list deep
+                    # copy breaks the virtualization mode combo box, making
+                    # the default mode appear as
+                    # `<object object at 0xaddress>`.
+                    bootmode_widget_data = list(zip(
+                        self.bootmode_names, self.bootmode_ids
+                    ))
+                    bootmode_widget_data.sort()
+                    utils.initialize_widget_for_property(
+                        widget=self.appvm_default_bootmode,
+                        choices=bootmode_widget_data,
+                        property_name="appvm_default_bootmode",
+                        holder=self.vm,
+                        allow_default=True,
+                        default_text_provider=get_default_bootmode_name
+                    )
+                if self.vm.bootmode != "default":
+                    self.bootmode_kernel_opts.setText(
+                        self.vm.features.check_with_template(
+                            f"boot-mode.kernelopts.{self.vm.bootmode}",
+                            ""
+                        )
+                    )
+                else:
+                    self.bootmode_kernel_opts.setText("")
+                self.bootmode.currentIndexChanged.connect(self.bootmode_changed)
             except qubesadmin.exc.QubesDaemonAccessError:
                 self.kernel_groupbox.setVisible(False)
                 self.kernel.setEnabled(False)
@@ -1027,6 +1109,13 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
             try:
                 if utils.did_widget_selection_change(self.kernel):
                     self.vm.kernel = self.kernel.currentData()
+                if utils.did_widget_selection_change(self.bootmode):
+                    self.vm.bootmode = self.bootmode.currentData()
+                if hasattr(self.vm, "appvm_default_bootmode"):
+                    if utils.did_widget_selection_change(
+                        self.appvm_default_bootmode):
+                        self.vm.appvm_default_bootmode \
+                            = self.appvm_default_bootmode.currentData()
             except qubesadmin.exc.QubesException as ex:
                 msg.append(str(ex))
 
@@ -1212,6 +1301,30 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
             return False
 
         return (int(m.group(1)), int(m.group(2))) >= (4, 11)
+
+    def update_bootmode_kernel_opts(self):
+        active_bootmode = self.bootmode.currentData()
+        if isinstance(active_bootmode, str):
+            self.bootmode_kernel_opts.setText(
+                self.vm.features.check_with_template(
+                    f"boot-mode.kernelopts.{active_bootmode}",
+                    ""
+                )
+            )
+        else:
+            default_bootmode = self.vm.property_get_default("bootmode")
+            if default_bootmode == "default":
+                self.bootmode_kernel_opts.setText("")
+            else:
+                self.bootmode_kernel_opts.setText(
+                    self.vm.features.check_with_template(
+                        f"boot-mode.kernelopts.{default_bootmode}",
+                        ""
+                    )
+                )
+
+    def bootmode_changed(self):
+        self.update_bootmode_kernel_opts()
 
     ######## devices tab
     def __init_devices_tab__(self):

--- a/qubesmanager/utils.py
+++ b/qubesmanager/utils.py
@@ -201,7 +201,8 @@ def initialize_widget(widget, choices, selected_value=None,
 
 def initialize_widget_for_property(*, widget, choices, holder, property_name,
                                    allow_default=False, icon_getter=None,
-                                   add_current_label=True):
+                                   add_current_label=True,
+                                   default_text_provider=None):
     """
     populates widget (ListBox or ComboBox) with items, based on a listed
     property. Supports discovering the system default for the given property
@@ -217,6 +218,9 @@ def initialize_widget_for_property(*, widget, choices, holder, property_name,
     :param icon_getter: a function applied to values (from choices) that
         returns a QIcon to be used as a item icon; default None
     :param add_current_label: if initial value should be labelled as (current)
+    :param default_text_provider: a function that will calculate the text for
+        the default option using the property holder and property value as
+        input
     :return:
     """
     if allow_default:
@@ -226,9 +230,15 @@ def initialize_widget_for_property(*, widget, choices, holder, property_name,
             default_property = "ERROR: unavailable"
         if default_property is None:
             default_property = "none"
-        choices.append(
-            (translate("default ({})").format(default_property),
-             qubesadmin.DEFAULT))
+        if default_text_provider is None:
+            choices.append(
+                (translate("default ({})").format(default_property),
+                qubesadmin.DEFAULT))
+        else:
+            choices.append(
+                (translate("default ({})").format(
+                    default_text_provider(holder, default_property)
+                ), qubesadmin.DEFAULT))
 
     # calculate current (can be default)
     try:

--- a/qubesmanager/utils.py
+++ b/qubesmanager/utils.py
@@ -36,6 +36,7 @@ import qubesimgconverter
 import xdg.BaseDirectory
 import pathlib
 import shutil
+import copy
 
 from PyQt6 import QtWidgets, QtCore, QtGui  # pylint: disable=import-error
 import qasync
@@ -223,6 +224,7 @@ def initialize_widget_for_property(*, widget, choices, holder, property_name,
         input
     :return:
     """
+    choices_copy = copy.copy(choices)
     if allow_default:
         try:
             default_property = holder.property_get_default(property_name)
@@ -231,11 +233,11 @@ def initialize_widget_for_property(*, widget, choices, holder, property_name,
         if default_property is None:
             default_property = "none"
         if default_text_provider is None:
-            choices.append(
+            choices_copy.append(
                 (translate("default ({})").format(default_property),
                 qubesadmin.DEFAULT))
         else:
-            choices.append(
+            choices_copy.append(
                 (translate("default ({})").format(
                     default_text_provider(holder, default_property)
                 ), qubesadmin.DEFAULT))
@@ -252,7 +254,7 @@ def initialize_widget_for_property(*, widget, choices, holder, property_name,
         current_value = getattr(holder, property_name)
 
     initialize_widget(widget,
-                      choices,
+                      choices_copy,
                       selected_value=current_value,
                       icon_getter=icon_getter,
                       add_current_label=add_current_label)

--- a/ui/settingsdlg.ui
+++ b/ui/settingsdlg.ui
@@ -943,6 +943,9 @@ The qube must be running to disable seamless mode. This setting is not persisten
                <widget class="QComboBox" name="kernel"/>
               </item>
               <item row="1" column="1">
+               <widget class="QComboBox" name="bootmode"/>
+              </item>
+              <item row="3" column="1">
                <widget class="QLabel" name="pvh_kernel_version_warning">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
@@ -965,7 +968,7 @@ The qube must be running to disable seamless mode. This setting is not persisten
                 </property>
                </widget>
               </item>
-              <item row="2" column="0">
+              <item row="5" column="0">
                <widget class="QLabel" name="label_20">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
@@ -974,11 +977,11 @@ The qube must be running to disable seamless mode. This setting is not persisten
                  </sizepolicy>
                 </property>
                 <property name="text">
-                 <string>Kernel opts:</string>
+                 <string>Extra kernel opts:</string>
                 </property>
                </widget>
               </item>
-              <item row="2" column="1">
+              <item row="5" column="1">
                <widget class="QLabel" name="kernel_opts">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
@@ -997,6 +1000,72 @@ The qube must be running to disable seamless mode. This setting is not persisten
                   <weight>50</weight>
                   <italic>true</italic>
                   <bold>false</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>[]</string>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QComboBox" name="appvm_default_bootmode"/>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="label_25">
+                <property name="text">
+                 <string>Boot mode:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="appvm_default_bootmode_desc">
+                <property name="mouseTracking">
+                 <bool>true</bool>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true"/>
+                </property>
+                <property name="text">
+                 <string>Default boot mode for derived AppVMs:</string>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::AutoText</enum>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="0">
+               <widget class="QLabel" name="label_29">
+                <property name="text">
+                 <string>Boot mode kernel opts:</string>
+                </property>
+                <property name="wordWrap">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="1">
+               <widget class="QLabel" name="bootmode_kernel_opts">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>250</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <italic>true</italic>
                  </font>
                 </property>
                 <property name="text">
@@ -1402,7 +1471,7 @@ The qube must be running to disable seamless mode. This setting is not persisten
                 <bool>true</bool>
                </property>
                <attribute name="headerDefaultSectionSize">
-                <number>40</number>
+                <number>55</number>
                </attribute>
                <attribute name="headerStretchLastSection">
                 <bool>false</bool>


### PR DESCRIPTION
Adds the user interface elements described at https://github.com/QubesOS/qubes-issues/issues/9750#issuecomment-2655149125 to the settings UI.

Not fully tested, thus not ready for merge. It seems to work for the most part, but my PR for the backend has a problem that keeps me from changing AppVM's templates for some reason.