### PR TITLE
Add the feature to prohibit starting a qube

### DIFF
--- a/icons/ban.svg
+++ b/icons/ban.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-ban"><circle cx="12" cy="12" r="10" stroke="#404040"/><path d="m4.9 4.9 14.2 14.2" stroke="#404040"/></svg>

--- a/qubesmanager/tests/conftest.py
+++ b/qubesmanager/tests/conftest.py
@@ -27,6 +27,8 @@ def test_qubes_app():
     test_qapp = MockQubesComplete()
     test_qapp._qubes['sys-usb'].features[
         'supported-feature.keyboard-layout'] = '1'
+    test_qapp._qubes['test-standalone'].features['prohibit-start'] = \
+        'Control qube which should be start prohibited from Manager launch'
     test_qapp.update_vm_calls()
 
     return test_qapp

--- a/resources.qrc
+++ b/resources.qrc
@@ -3,6 +3,7 @@
     <file alias="add">icons/add.svg</file>
     <file alias="apps">icons/apps.svg</file>
     <file alias="backup">icons/backup.svg</file>
+    <file alias="ban">icons/ban.svg</file>
     <file alias="blank">icons/blank.svg</file>
     <file alias="checked">icons/checked.svg</file>
     <file alias="checkmark">icons/checkmark.svg</file>


### PR DESCRIPTION
Qube Manager part of preventing qubes with `prohibit-start` from being started. Showing special status icon and disabling start and related buttons.

Supplements: https://github.com/QubesOS/qubes-issues/issues/9622