### PR TITLE
Improve `Version information` dialog

### DIFF
--- a/qubesmanager/informationnotes.py
+++ b/qubesmanager/informationnotes.py
@@ -19,6 +19,7 @@
 #
 
 from PyQt6.QtWidgets import QDialog  # pylint: disable=import-error
+from PyQt6.QtGui import QFont  # pylint: disable=import-error
 
 from . import ui_informationnotes  # pylint: disable=no-name-in-module
 import subprocess
@@ -36,4 +37,5 @@ class InformationNotesDialog(ui_informationnotes.Ui_InformationNotesDialog,
         self.setupUi(self)
         details = subprocess.check_output(
             ['/usr/libexec/qubes-manager/qvm_about.sh'])
+        self.informationNotes.setFont(QFont('Monospace', 10))
         self.informationNotes.setText(details.decode())

--- a/qubesmanager/qvm_about.sh
+++ b/qubesmanager/qvm_about.sh
@@ -4,7 +4,7 @@ uname -sr
 echo "  "
 echo "Installed Packages:  "
 echo "  "
-dnf list installed |awk '$1~/qubes/ && $1!~/@qubes*/ { printf "%-50s\t%s \n",$1 ,$2}'
+dnf list --installed |awk '$1~/qubes/ && $1!~/@qubes*/ { printf "%-50s\t%s \n",$1 ,$2}'
 
 
 

--- a/ui/informationnotes.ui
+++ b/ui/informationnotes.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>600</width>
+    <width>800</width>
     <height>600</height>
    </rect>
   </property>


### PR DESCRIPTION
Add support for dnf5 (while preserving dnf4 compatibility)
Use Monospace font for Version information dialog

fixes: https://github.com/QubesOS/qubes-issues/issues/9798