### PR TITLE
add a warning box when connecting an anon vm to a non-anon gateway

### DIFF
--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -485,6 +485,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
         self.netVM.currentIndexChanged.connect(self.check_warn_dispvmnetvm)
         self.netVM.currentIndexChanged.connect(self.check_warn_templatenetvm)
         self.netVM.currentIndexChanged.connect(self.check_network_availability)
+        self.netVM.currentIndexChanged.connect(self.check_warn_anonnetvm)
 
         try:
             self.include_in_backups.setChecked(self.vm.include_in_backups)
@@ -744,6 +745,30 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
             self.warn_netvm_dispvm.setVisible(True)
         else:
             self.warn_netvm_dispvm.setVisible(False)
+
+    def check_warn_anonnetvm(self):
+        if 'anon-vm' not in self.vm.tags:
+            return
+
+        current_net_vm = self.netVM.currentData()
+
+        if current_net_vm is None:
+            return
+
+        if current_net_vm == qubesadmin.DEFAULT:
+            current_net_vm = self.vm.property_get_default('netvm')
+
+        if 'anon-gateway' not in current_net_vm.tags:
+            QtWidgets.QMessageBox.warning(
+                self,
+                self.tr("Warning!"),
+                self.tr(
+                    "Anonymous qubes must be connected to an anonymous gateway "
+                    "to ensure privacy and anonymity. By changing the net qube "
+                    "to a gateway that does not provide anonymity, your IP "
+                    "address will be leaked on the Internet. Continue at your "
+                    "own risk.")
+            )
 
     def rename_vm(self):
 

--- a/qubesmanager/tests/test_vm_settings.py
+++ b/qubesmanager/tests/test_vm_settings.py
@@ -93,6 +93,13 @@ def settings_fixture(request, qapp, test_qubes_app) -> Tuple[
         name="test-pci-dev", qapp=test_qubes_app, label="green",
         virt_mode='hvm'
     )
+
+    test_qubes_app._qubes['sys-whonix'] = MockQube(
+        name="sys-whonix", qapp=test_qubes_app, tags=['anon-gateway'])
+
+    test_qubes_app._qubes['anon-whonix'] = MockQube(
+        name="anon-whonix", qapp=test_qubes_app, tags=['anon-vm'])
+
     test_qubes_app._devices.append(
         MockDevice(test_qubes_app, 'pci', 'USB Controller', '00:03.2',
                    'dom0', attached='test-pci-dev'))
@@ -315,7 +322,6 @@ def test_102_change_netvm(settings_fixture):
     else:
         assert expected_call not in settings_window.qubesapp.actual_calls, \
             "Unnecessary NetVM change"
-
 
 @mock.patch('PyQt6.QtWidgets.QMessageBox.warning')
 @pytest.mark.parametrize("settings_fixture", ["fedora-35"], indirect=True)
@@ -581,6 +587,34 @@ def test_112_clonevm(mock_clone, settings_fixture):
     settings_window.clone_vm_button.click()
 
     mock_clone.assert_called_with(mock.ANY, mock.ANY, src_vm=vm)
+
+
+@mock.patch('PyQt6.QtWidgets.QMessageBox.warning')
+@pytest.mark.parametrize("settings_fixture", ["anon-whonix"], indirect=True)
+def test_113_change_netvm_anon(mock_warning, settings_fixture):
+    settings_window, page, vm_name = settings_fixture
+    vm = settings_window.qubesapp.domains[vm_name]
+
+    change_netvm_call = (vm_name, 'admin.vm.property.Set', 'netvm', b'sys-net')
+    get_tag_call = (vm_name, 'admin.vm.tag.Get', 'anon-vm', None)
+
+    assert settings_window.netVM.isEnabled()
+
+    _select_item(settings_window.netVM, "sys-net")
+
+    assert get_tag_call in settings_window.qubesapp.actual_calls
+
+    assert change_netvm_call not in settings_window.qubesapp.expected_calls
+    settings_window.qubesapp.expected_calls[change_netvm_call] = b'0\x00'
+
+    settings_window.accept()
+
+    settings_window.qubesapp.expected_calls[change_netvm_call] = b'0\x00'
+
+    assert mock_warning.call_count == 1, ("Didn't warn for changing netvm "
+                                          "on anon-vm")
+
+    assert change_netvm_call in settings_window.qubesapp.actual_calls
 
 
 # ADVANCED TAB


### PR DESCRIPTION
Related issue: https://github.com/QubesOS/qubes-issues/issues/8551

Anon AppVM like anon-whonix needs an anon-gateway like sys-whonix to provide a correct level of anonymity and privacy. This commit adds a warning when a user try to connect a VM with the tag anon-vm to a Net Qube that does not have the tag anon-gateway

For tests to pass, https://github.com/QubesOS/qubes-core-admin-client/pull/343 must be merged.

