### PR TITLE
Fix Backup toggle in Qube Manager

### DIFF
--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -548,8 +548,8 @@ class QubesTableModel(QAbstractTableModel):
             col_name = self.columns_indices[index.column()]
             if col_name == "Backup":
                 vm = self.qubes_cache.get_vm(index.row())
-                vm.vm.include_in_backups = value == Qt.CheckState.Checked
-                vm.inc_backup = value == Qt.CheckState.Checked
+                vm.vm.include_in_backups = value == Qt.CheckState.Checked.value
+                vm.inc_backup = value == Qt.CheckState.Checked.value
                 return True
         return False
 


### PR DESCRIPTION
Currently only unsets the backup check. Could not set it back.