### PR TITLE
restore_vm: Don't use warning MessageBox on success

### DIFF
--- a/qubesmanager/restore.py
+++ b/qubesmanager/restore.py
@@ -257,12 +257,12 @@ class RestoreVMsWindow(ui_restoredlg.Ui_Restore, QtWidgets.QWizard):
         self.progress_bar.setValue(100)
 
         if self.thread.msg:
-            QtWidgets.QMessageBox.warning(
-                self,
-                self.tr("Restore qubes"),
-                self.tr(self.thread.msg))
-
-        if self.thread.msg:
+            messagebox = (
+                QtWidgets.QMessageBox.information
+                if "successful" in self.thread.msg
+                else QtWidgets.QMessageBox.warning
+            )
+            messagebox(self, self.tr("Restore qubes"), self.tr(self.thread.msg))
             self.append_output(self.thread.msg)
 
         if self.showFileDialog.isChecked():


### PR DESCRIPTION
Show scary exclamation mark in QMessageBox.warning. Use QMessageBox information instead. Resolves [qubes-issues/8538 ](https://github.com/QubesOS/qubes-issues/issues/8538) after https://github.com/QubesOS/qubes-manager/commit/8500b3654523ebd31a66a5880271585c9cba9dc5