### PR TITLE
Skip updating disk size when qube is removed

### DIFF
--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -288,7 +288,7 @@ class VmInfo():
                         self.state['outdated'] = 'eol'
                 else:
                     self.state['outdated'] = ""
-        except (exc.QubesDaemonAccessError, exc.QubesVMNotFoundError):
+        except exc.QubesDaemonAccessError:
             pass
 
     def update(self, update_size_on_disk=False, event=None):
@@ -1188,9 +1188,12 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
 
     def update_running_size(self, *_args):
         for vm in self.qubes_app.domains:
-            if vm.is_running():
-                self.qubes_cache.get_vm(qid=vm.qid).update(
-                    update_size_on_disk=True, event='disk_size')
+            try:
+                if vm.is_running():
+                    self.qubes_cache.get_vm(qid=vm.qid).update(
+                        update_size_on_disk=True, event='disk_size')
+            except exc.QubesVMNotFoundError:
+                pass  # qube was destroyed in the meantime.
 
     def on_domain_added(self, _submitter, _event, vm, **_kwargs):
         try:


### PR DESCRIPTION
Fixes: https://github.com/QubesOS/qubes-issues/issues/10285
For: https://github.com/QubesOS/qubes-issues/issues/1512

---

I got to reproduce the issue:

- qube manager -> default-dvm settings -> preload 4 disposables -> preload 0 disposables -> click on qube manager

When clicking/focusing on qube manager, it triggers [QEvent.Type.WindowActivate](https://github.com/QubesOS/qubes-manager/blob/40fbf47c97df085b2a8315f728758606b1b6e3e9/qubesmanager/qube_manager.py#L927) which calls `VmManagerWindow.update_running_size()`.

I logged `would fail` the line above the pass and got confirmation that it would fail there. I could not get it to fail in other places.