### PR TITLE
Improve reactions to missing PCI devices

### DIFF
--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -1551,15 +1551,13 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
 
         # pylint: disable=too-few-public-methods
         class DevListWidgetItem(QtWidgets.QListWidgetItem):
-            def __init__(self, dev, unknown=False, parent=None):
+            def __init__(self, dev, parent=None):
                 super().__init__(parent)
                 name = (
                     dev.port_id.replace("_", ":").replace("-", " -> ")
                     + " "
                     + dev.description
                 )
-                if unknown:
-                    name += " (unknown)"
                 self.setText(name)
                 self.dev = dev
                 intfs = list({i.category for i in dev.interfaces})
@@ -1580,7 +1578,7 @@ class VMSettingsWindow(ui_settingsdlg.Ui_SettingsDialog, QtWidgets.QDialog):
         for ass in attached:
             if not any(ass.matches(dev) for dev in dom0_devs):
                 self.dev_list.selected_list.addItem(
-                    DevListWidgetItem(ass.device, unknown=True)
+                    DevListWidgetItem(ass.device)
                 )
 
         if (

--- a/qubesmanager/tests/test_vm_settings.py
+++ b/qubesmanager/tests/test_vm_settings.py
@@ -136,6 +136,21 @@ def settings_fixture(
         )
     )
 
+    # orphaned device
+    test_qubes_app._devices.append(
+        MockDevice(
+            test_qubes_app,
+            dev_class="pci",
+            device_id="0x8008:0x6789::p050000",
+            backend_vm="dom0",
+            port="00_04.3",
+            product="Weird Lost Device",
+            vendor="Test Vendor",
+            assigned=[("test-pci-dev", "required", None)],
+            device_unknown=True,
+        )
+    )
+
     # add a TemplateVM with some boot modes
     test_qubes_app._qubes["fedora-36-bootmodes"] = MockQube(
         name="fedora-36-bootmodes",
@@ -2007,8 +2022,9 @@ def test_602_device_remove(settings_fixture):
     selected_items = []
     for i in range(settings_window.dev_list.selected_list.count()):
         item = settings_window.dev_list.selected_list.item(i)
-        selected_items.append(item.text())
-        item.setSelected(True)
+        if "unknown " not in item.text():
+            selected_items.append(item.text())
+            item.setSelected(True)
 
     assert len(selected_items) == 1
 


### PR DESCRIPTION
Fix tests so that now they will fail if there is a bad reaction to an unknown PCI device. Clean-up handling unknown PCI devices by settigs.

requires https://github.com/QubesOS/qubes-core-admin-client/pull/400
 fixes QubesOS/qubes-issues#10409