### PR TITLE
template_manager: fix crash on double-click on a running qube

### DIFF
--- a/qubesmanager/template_manager.py
+++ b/qubesmanager/template_manager.py
@@ -201,11 +201,14 @@ class TemplateManagerWindow(
 
     def table_double_click(self, row, column):
         template_column = column_names.index('Current template')
-        current_state = self.vm_list.cellWidget(
-            row, column_names.index('State')).isChecked()
 
         if column != template_column:
             return
+
+        checkbox = self.vm_list.cellWidget(row, column_names.index('State'))
+        if not checkbox:
+            return
+        current_state = checkbox.isChecked()
 
         template_name = self.vm_list.item(row, column).text()
 


### PR DESCRIPTION
Fixes QubesOS/qubes-issues#10817

## Problem

Double-clicking a running qube in the Template Manager crashes with:

```
AttributeError: 'NoneType' object has no attribute 'isChecked'
  File "template_manager.py", line 205, in table_double_click
    row, column_names.index('State')).isChecked()
```

Running qubes have no checkbox in the State column — `cellWidget()`
returns `None` - but `isChecked()` was called on it unconditionally.

## Fix

- Move the `column != template_column` guard before the `cellWidget`
  call so we bail out early for irrelevant columns.
- After the guard, check that `cellWidget` returned a checkbox before
  calling `isChecked()`. If there is no checkbox (qube is running),
  return early - there is nothing to toggle.