### PR TITLE
Make Template Manager text selectable for copying

### DIFF
--- a/ui/qvmtemplate.ui
+++ b/ui/qvmtemplate.ui
@@ -62,6 +62,9 @@
              <property name="text">
               <string>lorem ipsum</string>
              </property>
+             <property name="textInteractionFlags">
+              <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+             </property>
              <property name="alignment">
               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
              </property>


### PR DESCRIPTION
In particular, the ability to copy the installed template version would be useful.

I assume this change compiles to the following line which I've manually inserted into the compiled `ui_qvmtemplate.py`:
```py
self.template_info.setTextInteractionFlags(QtCore.Qt.TextInteractionFlag.LinksAccessibleByMouse|QtCore.Qt.TextInteractionFlag.TextSelectableByMouse)
```