### PR TITLE
Remotefixes

### DIFF
--- a/qubesmanager/backup.py
+++ b/qubesmanager/backup.py
@@ -118,11 +118,14 @@ class BackupVMsWindow(ui_backupdlg.Ui_Backup, QtWidgets.QWizard):
 
         self.total_size = 0
 
+        # enable for RemoteVMs if qubes.SelectDirectory is implemented
+        # or if RemoteVM as backup target will work at all - then enable it while
+        # disabling the [...] select directory button
         utils.initialize_widget_with_vms(
             widget=self.appvm_combobox,
             qubes_app=self.qubes_app,
             filter_function=(lambda vm:
-                             vm.klass != 'TemplateVM'
+                             vm.klass != 'TemplateVM' and vm.klass != 'RemoteVM'
                              and utils.is_running(vm, False)
                             ),
         )
@@ -319,6 +322,8 @@ class BackupVMsWindow(ui_backupdlg.Ui_Backup, QtWidgets.QWizard):
     def __fill_vms_list__(self, selected=None):
         for vm in self.qubes_app.domains:
             if utils.get_feature(vm, 'internal', False):
+                continue
+            if vm.klass == 'RemoteVM':
                 continue
 
             item = BackupVMsWindow.VmListItem(vm)

--- a/qubesmanager/backup_utils.py
+++ b/qubesmanager/backup_utils.py
@@ -46,9 +46,13 @@ def fill_appvms_list(dialog):
     dialog.appvm_combobox.setCurrentIndex(0)  # current selected is null ""
 
     for vm in dialog.qubes_app.domains:
-        if utils.get_feature(vm, 'internal', False) or vm.klass == 'TemplateVM':
+        if utils.get_feature(vm, 'internal', False):
             continue
-
+        if vm.klass in ["TemplateVM", "RemoteVM"]:
+            # this should be enabled for RemoteVMs when qubes.SelectFile is implemented
+            # or if RemoteVM as backup target will work at all - then enable it while
+            # disabling the [...] select directory button
+            continue
         if utils.is_running(vm, False) and vm.klass != 'AdminVM':
             dialog.appvm_combobox.addItem(vm.name)
 

--- a/qubesmanager/bootfromdevice.py
+++ b/qubesmanager/bootfromdevice.py
@@ -19,6 +19,8 @@
 
 import functools
 import subprocess
+import sys
+
 from . import utils
 from . import ui_bootfromdevice  # pylint: disable=no-name-in-module
 from PyQt6 import QtWidgets, QtGui, QtCore  # pylint: disable=import-error
@@ -40,6 +42,13 @@ class VMBootFromDeviceWindow(ui_bootfromdevice.Ui_BootDialog,
         self.qubesapp = qubesapp
         self.cdrom_location = None
         self.new_vm = new_vm
+
+        if vm.klass in ["RemoteVM", "AdminVM"]:
+            QtWidgets.QMessageBox.warning(
+                self,
+                self.tr("Error!"),
+                self.tr("A {} qube cannot be booted from a device.".format(vm.klass)))
+            sys.exit(1)
 
         self.setupUi(self)
         self.setWindowTitle(
@@ -108,12 +117,15 @@ class VMBootFromDeviceWindow(ui_bootfromdevice.Ui_BootDialog,
         utils.initialize_widget_with_vms(
             widget=self.fileVM,
             qubes_app=self.qubesapp,
-            filter_function=(lambda vm: vm != self.vm and vm.klass != "TemplateVM"),
+            filter_function=(lambda vm: vm != self.vm and vm.klass != "TemplateVM"
+                                        and vm.klass != "RemoteVM"),
         )
 
         device_choice = []
 
         for domain in self.qubesapp.domains:
+            if domain.klass == 'RemoteVM':
+                continue
             try:
                 for device in domain.devices["block"]:
                     device_choice.append((str(device), device))

--- a/qubesmanager/clone_vm.py
+++ b/qubesmanager/clone_vm.py
@@ -54,7 +54,7 @@ class CloneVMDlg(QtWidgets.QDialog, Ui_CloneVMDlg):
         utils.initialize_widget_with_vms(
             widget=self.src_vm,
             qubes_app=self.app,
-            filter_function=lambda vm: vm.klass != 'AdminVM')
+            filter_function=lambda vm: vm.klass not in ['AdminVM', 'RemoteVM'])
 
         if src_vm and self.src_vm.findText(src_vm.name) > -1:
             self.src_vm.setCurrentIndex(self.src_vm.findText(src_vm.name))
@@ -172,6 +172,10 @@ def main(args=None):
         src_vm = args.domains.pop()
     else:
         src_vm = None
+
+    if src_vm and src_vm.klass in ['AdminVM', 'RemoteVM']:
+        print("A {} qube cannot be cloned.".format(src_vm.klass))
+        sys.exit(1)
 
     qtapp = QtWidgets.QApplication(sys.argv)
 

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -374,7 +374,7 @@ class VmInfo():
                     self.dvm = "default (" + str(self.dvm) + ")"
                 elif self.dvm is not None:
                     self.dvm = str(self.dvm)
-            except exc.QubesDaemonAccessError:
+            except (exc.QubesDaemonAccessError, AttributeError):
                 if self.dvm is not None:
                     self.dvm = str(self.dvm)
 
@@ -1164,7 +1164,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
         action.triggered.connect(partial(self.change_network, 'default'))
 
         for vm in self.qubes_app.domains:
-            if vm.qid != 0 and vm.provides_network:
+            if vm.qid != 0 and getattr(vm, "provides_network", False):
                 action = self.network_menu.addAction(vm.name)
                 action.setData(vm.name)
                 action.triggered.connect(partial(self.change_network, vm.name))
@@ -1418,6 +1418,21 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
                 self.action_open_console.setEnabled(False)
 
             if vm.klass == 'AdminVM':
+                self.action_open_console.setEnabled(False)
+                self.action_settings.setEnabled(False)
+                self.action_resumevm.setEnabled(False)
+                self.action_removevm.setEnabled(False)
+                self.action_clonevm.setEnabled(False)
+                self.action_pausevm.setEnabled(False)
+                self.action_restartvm.setEnabled(False)
+                self.action_killvm.setEnabled(False)
+                self.action_shutdownvm.setEnabled(False)
+                self.action_appmenus.setEnabled(False)
+                self.action_editfwrules.setEnabled(False)
+                self.action_run_command_in_vm.setEnabled(False)
+                self.template_menu.setEnabled(False)
+                self.network_menu.setEnabled(False)
+            elif vm.klass == "RemoteVM":
                 self.action_open_console.setEnabled(False)
                 self.action_settings.setEnabled(False)
                 self.action_resumevm.setEnabled(False)

--- a/qubesmanager/qube_manager.py
+++ b/qubesmanager/qube_manager.py
@@ -1432,6 +1432,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
                 self.action_run_command_in_vm.setEnabled(False)
                 self.template_menu.setEnabled(False)
                 self.network_menu.setEnabled(False)
+                self.action_startvm_tools_install.setEnabled(False)
             elif vm.klass == "RemoteVM":
                 self.action_open_console.setEnabled(False)
                 self.action_settings.setEnabled(False)
@@ -1447,6 +1448,7 @@ class VmManagerWindow(ui_qubemanager.Ui_VmManagerWindow, QMainWindow):
                 self.action_run_command_in_vm.setEnabled(False)
                 self.template_menu.setEnabled(False)
                 self.network_menu.setEnabled(False)
+                self.action_startvm_tools_install.setEnabled(False)
             elif vm.klass == 'DispVM':
                 self.action_appmenus.setEnabled(False)
                 if vm.auto_cleanup:

--- a/qubesmanager/settings.py
+++ b/qubesmanager/settings.py
@@ -2027,14 +2027,14 @@ parser.set_defaults(
 def main(args=None):
     args = parser.parse_args(args)
     vm = args.domains.pop()
-    if vm.klass == "AdminVM":
+    if vm.klass in ["AdminVM", "RemoteVM"]:
         print(
             "This tool cannot be used to change properties of an "
-            f"AdminVM ({vm.name})."
+            f"{vm.klass} ({vm.name})."
         )
         print(
             "You can use command-line tools such as qvm-prefs "
-            "and qvm-features to change properties of an AdminVM"
+            f"and qvm-features to change properties of a {vm.klass}"
         )
         return 1
 


### PR DESCRIPTION
Makes manager remotevm-proof.
- remove them from target and source of backup (once this works, this could be restored)
- remove them from possible backuped qube (once this works, this could be restored)
- do not allow managing them with qube manager, but show them in the list
- do not allow cloning them or booting them from device (also misc fix for clone gui that could be run on AdminVM)
- also stop qubes-windows-tools installation button to be enabled for remotevms and adminvms

references QubesOS/qubes-issues#10121
fixes https://github.com/QubesOS/qubes-issues/issues/10898