### PR TITLE
Use device port as boot device identifier

### DIFF
--- a/qubesmanager/bootfromdevice.py
+++ b/qubesmanager/bootfromdevice.py
@@ -85,7 +85,8 @@ class VMBootFromDeviceWindow(ui_bootfromdevice.Ui_BootDialog, QtWidgets.QDialog)
 
     def save_and_apply(self):
         if self.blockDeviceRadioButton.isChecked():
-            self.cdrom_location = self.blockDeviceComboBox.currentText()
+            device = self.blockDeviceComboBox.currentData()
+            self.cdrom_location = str(device.port)
         elif self.fileRadioButton.isChecked():
             self.cdrom_location = (
                 str(self.fileVM.currentData()) + ":" + self.pathText.text()
@@ -153,7 +154,7 @@ class VMBootFromDeviceWindow(ui_bootfromdevice.Ui_BootDialog, QtWidgets.QDialog)
                 continue
             try:
                 for device in domain.devices["block"]:
-                    device_choice.append((str(device), device))
+                    device_choice.append((str(device.port), device))
             except exc.QubesDaemonAccessError:
                 # insufficient permissions
                 pass


### PR DESCRIPTION
The block device combo box was filled with str(device), i.e. "<backend>:<port_id>:<device_id>", and that text was passed as-is to get_drive_assignment(), which expects "<backend>:<port_id>". qubesd rejected the assignment and the qube silently did not start:

    ProtocolError: Got device from port: loop0::0 when expected port: loop0

Use str(device.port) for both the label and the value, which also matches qvm-block list output.

Fixes: https://github.com/QubesOS/qubes-issues/issues/10164